### PR TITLE
take trailing trash into account

### DIFF
--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -447,7 +447,7 @@ class VarnishPurger {
 				'parent' => 'purge-varnish-cache',
 				'id'     => 'purge-varnish-cache-this',
 				'title'  => __( 'Purge Cache (This Page)', 'varnish-http-purge' ),
-				'href'   => wp_nonce_url( add_query_arg( 'vhp_flush_do', $page_url . '/' ), 'vhp-flush-do' ),
+				'href'   => wp_nonce_url( add_query_arg( 'vhp_flush_do', $page_url . $this->get_trailing_slash() ), 'vhp-flush-do' ),
 				'meta'   => array(
 					'title' => __( 'Purge Cache (This Page)', 'varnish-http-purge' ),
 				),
@@ -459,6 +459,17 @@ class VarnishPurger {
 				$admin_bar->add_node( $arg );
 			}
 		}
+	}
+
+	protected function get_trailing_slash() {
+		$permalink_structure = get_option( 'permalink_structure' );
+		if ( empty( $permalink_structure ) ) {
+			return '';
+		}
+		if ( substr( $permalink_structure, -1 ) === '/' ) {
+			return '/';
+		}
+		return '';
 	}
 
 	/**

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -1030,7 +1030,7 @@ class VarnishPurger {
 			array_push(
 				$listofurls,
 				get_rest_url(),
-				$this->the_home_url() . '/'
+				$this->the_home_url() . $this->get_trailing_slash() 
 			);
 			if ( 'page' === get_site_option( 'show_on_front' ) ) {
 				// Ensure we have a page_for_posts setting to avoid empty URL.

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -447,7 +447,7 @@ class VarnishPurger {
 				'parent' => 'purge-varnish-cache',
 				'id'     => 'purge-varnish-cache-this',
 				'title'  => __( 'Purge Cache (This Page)', 'varnish-http-purge' ),
-				'href'   => wp_nonce_url( add_query_arg( 'vhp_flush_do', $page_url . $this->get_trailing_slash() ), 'vhp-flush-do' ),
+				'href'   => wp_nonce_url( add_query_arg( 'vhp_flush_do', user_trailingslashit( $page_url ) ), 'vhp-flush-do' ),
 				'meta'   => array(
 					'title' => __( 'Purge Cache (This Page)', 'varnish-http-purge' ),
 				),
@@ -461,16 +461,6 @@ class VarnishPurger {
 		}
 	}
 
-	protected function get_trailing_slash() {
-		$permalink_structure = get_option( 'permalink_structure' );
-		if ( empty( $permalink_structure ) ) {
-			return '';
-		}
-		if ( substr( $permalink_structure, -1 ) === '/' ) {
-			return '/';
-		}
-		return '';
-	}
 
 	/**
 	 * Get the icon as SVG.
@@ -1030,7 +1020,7 @@ class VarnishPurger {
 			array_push(
 				$listofurls,
 				get_rest_url(),
-				$this->the_home_url() . $this->get_trailing_slash() 
+				user_trailingslashit( $this->the_home_url() )
 			);
 			if ( 'page' === get_site_option( 'show_on_front' ) ) {
 				// Ensure we have a page_for_posts setting to avoid empty URL.


### PR DESCRIPTION
If your site does not use trailing slashes, this plugin does not work fully.

Especially the "Purge Cache (This Page)" is not usable, as it will try to flush a page url that varnish has not cached.