### PR TITLE
Allow custom header to be set in more ways

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -331,8 +331,8 @@ add_filter( 'varnish_http_purge_headers', function( $headers ) {
     $headers['X-Control-Key'] = 'YOUR_CONTROL_KEY_HERE';
 
     // Or use Authorization headers:
-    $headers['Authorization'] = 'Basic ' . base64_encode( 'username:password' );
-    $headers['Authorization'] = 'Bearer ' . 'YOUR_TOKEN_HERE';
+    // $headers['Authorization'] = 'Basic ' . base64_encode( 'username:password' );
+    // $headers['Authorization'] = 'Bearer ' . 'YOUR_TOKEN_HERE';
 
     return $headers;
 } );

--- a/readme.txt
+++ b/readme.txt
@@ -309,7 +309,12 @@ This is a question beyond the support of this plugin. I do not have the resource
 
 = How do I pass a Varnish control key or auth header? =
 
-Some providers require a control key, token, or Authorization header to accept PURGE requests. The plugin doesn’t have a dedicated constant for this, but you can inject any required header via a filter.
+Some providers require a control key, token, or Authorization header to accept PURGE requests. You can set a header name and value via the settings page or via the following constant:
+<code>
+define( 'VHP_VARNISH_HEADER', 'X-Control-Key: YOUR_CONTROL_KEY_HERE' );
+</code>
+
+Alternatively, you can inject any required header via a filter.
 
 1. Set where PURGE requests should be sent (host:port, no scheme):
 
@@ -326,8 +331,8 @@ add_filter( 'varnish_http_purge_headers', function( $headers ) {
     $headers['X-Control-Key'] = 'YOUR_CONTROL_KEY_HERE';
 
     // Or use Authorization headers:
-    // $headers['Authorization'] = 'Basic ' . base64_encode( 'username:password' );
-    // $headers['Authorization'] = 'Bearer ' . 'YOUR_TOKEN_HERE';
+    $headers['Authorization'] = 'Basic ' . base64_encode( 'username:password' );
+    $headers['Authorization'] = 'Bearer ' . 'YOUR_TOKEN_HERE';
 
     return $headers;
 } );

--- a/readme.txt
+++ b/readme.txt
@@ -311,7 +311,7 @@ This is a question beyond the support of this plugin. I do not have the resource
 
 Some providers require a control key, token, or Authorization header to accept PURGE requests. You can set a header name and value via the settings page or via the following constant:
 <code>
-define( 'VHP_VARNISH_HEADER', 'X-Control-Key: YOUR_CONTROL_KEY_HERE' );
+define( 'VHP_VARNISH_EXTRA_PURGE_HEADER', 'X-Control-Key: YOUR_CONTROL_KEY_HERE' );
 </code>
 
 Alternatively, you can inject any required header via a filter.

--- a/settings.php
+++ b/settings.php
@@ -55,30 +55,30 @@ class VarnishStatus {
 	public function register_settings() {
 		// Development Mode Settings.
 		register_setting( 'vhp-settings-devmode', 'vhp_varnish_devmode', array( &$this, 'settings_devmode_sanitize' ) );
-		add_settings_section( 'vhp-settings-devmode-section', __( 'Development mode settings', 'varnish-http-purge' ), array( &$this, 'options_settings_devmode' ), 'varnish-devmode-settings' );
-		add_settings_field( 'varnish_devmode', __( 'Development mode', 'varnish-http-purge' ), array( &$this, 'settings_devmode_callback' ), 'varnish-devmode-settings', 'vhp-settings-devmode-section' );
+		add_settings_section( 'vhp-settings-devmode-section', __( 'Development Mode Settings', 'varnish-http-purge' ), array( &$this, 'options_settings_devmode' ), 'varnish-devmode-settings' );
+		add_settings_field( 'varnish_devmode', __( 'Development Mode', 'varnish-http-purge' ), array( &$this, 'settings_devmode_callback' ), 'varnish-devmode-settings', 'vhp-settings-devmode-section' );
 
 		// Purge Method settings (Cache Tags)
 		register_setting( 'vhp-settings-tags', 'vhp_varnish_use_tags', array( &$this, 'settings_tags_sanitize' ) );
 		add_settings_section( 'vhp-settings-tags-section', __( 'Purge Method', 'varnish-http-purge' ), array( &$this, 'options_settings_tags' ), 'varnish-tags-settings' );
 		add_settings_field( 'varnish_use_tags', __( 'Use Cache Tags', 'varnish-http-purge' ), array( &$this, 'settings_tags_callback' ), 'varnish-tags-settings', 'vhp-settings-tags-section' );
 
-		// Purge All settings
+		// Purge All settings.
 		register_setting( 'vhp-settings-maxposts', 'vhp_varnish_max_posts_before_all', array( &$this, 'settings_maxposts_sanitize' ) );
-		add_settings_section( 'vhp-settings-maxposts-section', __( 'Maximum individual URLs before full purge', 'varnish-http-purge' ), array( &$this, 'options_settings_maxposts' ), 'varnish-maxposts-settings' );
-		add_settings_field( 'varnish_maxposts', __( 'Set max URLs', 'varnish-http-purge' ), array( &$this, 'settings_maxposts_callback' ), 'varnish-maxposts-settings', 'vhp-settings-maxposts-section' );
+		add_settings_section( 'vhp-settings-maxposts-section', __( 'Maximum Individual URLs before Full Purge', 'varnish-http-purge' ), array( &$this, 'options_settings_maxposts' ), 'varnish-maxposts-settings' );
+		add_settings_field( 'varnish_maxposts', __( 'Set Max URLs', 'varnish-http-purge' ), array( &$this, 'settings_maxposts_callback' ), 'varnish-maxposts-settings', 'vhp-settings-maxposts-section' );
 
 		// IP Settings.
 		register_setting( 'vhp-settings-ip', 'vhp_varnish_ip', array( &$this, 'settings_ip_sanitize' ) );
-		add_settings_section( 'vhp-settings-ip-section', __( 'Configure custom IP', 'varnish-http-purge' ), array( &$this, 'options_settings_ip' ), 'varnish-ip-settings' );
-		add_settings_field( 'varnish_ip', __( 'Set custom IP', 'varnish-http-purge' ), array( &$this, 'settings_ip_callback' ), 'varnish-ip-settings', 'vhp-settings-ip-section' );
+		add_settings_section( 'vhp-settings-ip-section', __( 'Configure Custom IP', 'varnish-http-purge' ), array( &$this, 'options_settings_ip' ), 'varnish-ip-settings' );
+		add_settings_field( 'varnish_ip', __( 'Set Custom IP', 'varnish-http-purge' ), array( &$this, 'settings_ip_callback' ), 'varnish-ip-settings', 'vhp-settings-ip-section' );
 
-		// Purge All settings
+		// Purge Headers settings.
 		register_setting( 'vhp-settings-purgeheader', 'vhp_varnish_header_name', array( &$this, 'settings_purgeheaders_name_sanitize' ) );
 		register_setting( 'vhp-settings-purgeheader', 'vhp_varnish_header_value', array( &$this, 'settings_purgeheaders_value_sanitize' ) );
-		add_settings_section( 'vhp-settings-purgeheader-section', __( 'Purge headers', 'varnish-http-purge' ), array( &$this, 'options_settings_purgeheaders' ), 'varnish-purgeheader-settings' );
-		add_settings_field( 'varnish_purgeheaders_name', __( 'Set purge header name', 'varnish-http-purge' ), array( &$this, 'settings_purgeheaders_name_callback' ), 'varnish-purgeheader-settings', 'vhp-settings-purgeheader-section' );
-		add_settings_field( 'varnish_purgeheaders_value', __( 'Set purge header value', 'varnish-http-purge' ), array( &$this, 'settings_purgeheaders_value_callback' ), 'varnish-purgeheader-settings', 'vhp-settings-purgeheader-section' );
+		add_settings_section( 'vhp-settings-purgeheader-section', __( 'Purge Headers', 'varnish-http-purge' ), array( &$this, 'options_settings_purgeheaders' ), 'varnish-purgeheader-settings' );
+		add_settings_field( 'varnish_purgeheaders_name', __( 'Set Purge Header Name', 'varnish-http-purge' ), array( &$this, 'settings_purgeheaders_name_callback' ), 'varnish-purgeheader-settings', 'vhp-settings-purgeheader-section' );
+		add_settings_field( 'varnish_purgeheaders_value', __( 'Set Purge Header Value', 'varnish-http-purge' ), array( &$this, 'settings_purgeheaders_value_callback' ), 'varnish-purgeheader-settings', 'vhp-settings-purgeheader-section' );
 	}
 
 	/**
@@ -719,7 +719,7 @@ sub vcl_recv {
 				<?php
 					settings_fields( 'vhp-settings-devmode' );
 					do_settings_sections( 'varnish-devmode-settings' );
-					submit_button( __( 'Save devmode settings', 'varnish-http-purge' ), 'primary' );
+					submit_button( __( 'Save Devmode Settings', 'varnish-http-purge' ), 'primary' );
 				?>
 				</form>
 
@@ -735,7 +735,7 @@ sub vcl_recv {
 				<?php
 					settings_fields( 'vhp-settings-maxposts' );
 					do_settings_sections( 'varnish-maxposts-settings' );
-					submit_button( __( 'Save maxposts settings', 'varnish-http-purge' ), 'primary' );
+					submit_button( __( 'Save Maxposts Settings', 'varnish-http-purge' ), 'primary' );
 				?>
 				</form>
 
@@ -743,7 +743,7 @@ sub vcl_recv {
 				<?php
 					settings_fields( 'vhp-settings-ip' );
 					do_settings_sections( 'varnish-ip-settings' );
-					submit_button( __( 'Save IP settings', 'varnish-http-purge' ), 'secondary' );
+					submit_button( __( 'Save IP Settings', 'varnish-http-purge' ), 'secondary' );
 				?>
 				</form>
 
@@ -751,7 +751,7 @@ sub vcl_recv {
 					<?php
 					settings_fields( 'vhp-settings-purgeheader' );
 					do_settings_sections( 'varnish-purgeheader-settings' );
-					submit_button( __( 'Save purge header settings', 'varnish-http-purge' ), 'primary' );
+					submit_button( __( 'Save Purge Header Settings', 'varnish-http-purge' ), 'primary' );
 					?>
 				</form>
 				<?php

--- a/settings.php
+++ b/settings.php
@@ -76,7 +76,7 @@ class VarnishStatus {
 		// Purge All settings
 		register_setting( 'vhp-settings-purgeheader', 'vhp_varnish_header_name', array( &$this, 'settings_purgeheaders_name_sanitize' ) );
 		register_setting( 'vhp-settings-purgeheader', 'vhp_varnish_header_value', array( &$this, 'settings_purgeheaders_value_sanitize' ) );
-		add_settings_section( 'vhp-settings-purgeheader-section', __( 'Purge Headers', 'varnish-http-purge' ), array( &$this, 'options_settings_purgeheaders' ), 'varnish-purgeheader-settings' );
+		add_settings_section( 'vhp-settings-purgeheader-section', __( 'Purge headers', 'varnish-http-purge' ), array( &$this, 'options_settings_purgeheaders' ), 'varnish-purgeheader-settings' );
 		add_settings_field( 'varnish_purgeheaders_name', __( 'Set purge header name', 'varnish-http-purge' ), array( &$this, 'settings_purgeheaders_name_callback' ), 'varnish-purgeheader-settings', 'vhp-settings-purgeheader-section' );
 		add_settings_field( 'varnish_purgeheaders_value', __( 'Set purge header value', 'varnish-http-purge' ), array( &$this, 'settings_purgeheaders_value_callback' ), 'varnish-purgeheader-settings', 'vhp-settings-purgeheader-section' );
 	}

--- a/settings.php
+++ b/settings.php
@@ -447,7 +447,7 @@ sub vcl_recv {
 	 */
 	public function options_settings_purgeheaders() {
 		?>
-		<p><a name="#configurepurgeheaders"></a>
+		<p><a id="configurepurgeheaders"></a>
 			<strong><?php esc_html_e( 'Advanced:', 'varnish-http-purge' ); ?></strong>
 			<?php esc_html_e( 'Only configure this if your hosting provider or cache service explicitly documents a required control or Authorization header for PURGE requests. If you are not sure, leave these fields empty.', 'varnish-http-purge' ); ?>
 		</p>
@@ -468,8 +468,8 @@ sub vcl_recv {
 		}
 
 		?>
-		<input type="text" id="vph_varnish_header_name" name="vhp_varnish_header_name" value="<?php echo esc_attr( $header_name ); ?>" size="25" <?php disabled( $disabled, true ); ?> />
-		<label for="vph_varnish_header_name">&nbsp;
+		<input type="text" id="vhp_varnish_header_name" name="vhp_varnish_header_name" value="<?php echo esc_attr( $header_name ); ?>" size="25" <?php disabled( $disabled, true ); ?> />
+		<label for="vhp_varnish_header_name">&nbsp;
 		<?php
 		if ( $disabled ) {
 			esc_html_e( 'The header has been defined in your wp-config file, so it is not editable in settings.', 'varnish-http-purge' );
@@ -485,14 +485,27 @@ sub vcl_recv {
 		$disabled = false;
 		if ( defined( 'VHP_VARNISH_EXTRA_PURGE_HEADER' ) && false !== VHP_VARNISH_EXTRA_PURGE_HEADER ) {
 			$disabled     = true;
-			$header_value = trim( explode( ':', VHP_VARNISH_EXTRA_PURGE_HEADER )[1] );
+			$header_value = '';
+
+			if ( strpos( VHP_VARNISH_EXTRA_PURGE_HEADER, ':' ) !== false ) {
+				$parts = explode( ':', VHP_VARNISH_EXTRA_PURGE_HEADER, 2 );
+				if ( isset( $parts[1] ) ) {
+					$header_value = trim( $parts[1] );
+				}
+			}
+
+			// If the constant is malformed (no value part), fall back to the stored option
+			// so that the field still displays something meaningful.
+			if ( '' === $header_value ) {
+				$header_value = get_site_option( 'vhp_varnish_header_value' );
+			}
 		} else {
 			$header_value = get_site_option( 'vhp_varnish_header_value' );
 		}
 
 		?>
-		<input type="password" id="vph_varnish_header_value" name="vhp_varnish_header_value" value="<?php echo esc_attr( $header_value ); ?>" size="25" <?php disabled( $disabled, true ); ?> autocomplete="off" />
-		<label for="vph_varnish_header_value">&nbsp;
+		<input type="password" id="vhp_varnish_header_value" name="vhp_varnish_header_value" value="<?php echo esc_attr( $header_value ); ?>" size="25" <?php disabled( $disabled, true ); ?> autocomplete="off" />
+		<label for="vhp_varnish_header_value">&nbsp;
 		<?php
 		if ( $disabled ) {
 			esc_html_e( 'The value has been defined in your wp-config file, so it is not editable in settings.', 'varnish-http-purge' );
@@ -502,37 +515,43 @@ sub vcl_recv {
 
 	public function settings_purgeheaders_name_sanitize( $input ) {
 		$output      = '';
-		$set_message = __( 'You have entered an invalid header name.', 'varnish-http-purge' );
-		$set_type    = 'error';
+		$set_message = '';
+		$set_type    = 'updated';
 
-		if ( empty( $input ) ) {
-			return;
-		}
-		if ( is_string( $input ) ) {
-			$set_message = __( 'Purge header updated', 'varnish-http-purge' );
-			$set_type    = 'updated';
+		if ( ! is_string( $input ) || '' === trim( $input ) ) {
+			// Treat empty or non-string input as a request to clear the header.
+			$set_message = __( 'Purge header name cleared.', 'varnish-http-purge' );
+			$output      = '';
+		} else {
+			$set_message = __( 'Purge header name updated.', 'varnish-http-purge' );
 			$output      = sanitize_text_field( $input );
 		}
 
-		add_settings_error( 'vhp_varnish_header_name', 'varnish-purgeheader', $set_message, $set_type );
+		if ( $set_message ) {
+			add_settings_error( 'vhp_varnish_header_name', 'varnish-purgeheader', $set_message, $set_type );
+		}
+
 		return $output;
 	}
 
 	public function settings_purgeheaders_value_sanitize( $input ) {
 		$output      = '';
-		$set_message = __( 'You have entered an invalid header value.', 'varnish-http-purge' );
-		$set_type    = 'error';
+		$set_message = '';
+		$set_type    = 'updated';
 
-		if ( empty( $input ) ) {
-			return;
-		}
-		if ( is_string( $input ) ) {
-			$set_message = __( 'Purge header value updated', 'varnish-http-purge' );
-			$set_type    = 'updated';
+		if ( ! is_string( $input ) || '' === trim( $input ) ) {
+			// Treat empty or non-string input as a request to clear the header value.
+			$set_message = __( 'Purge header value cleared.', 'varnish-http-purge' );
+			$output      = '';
+		} else {
+			$set_message = __( 'Purge header value updated.', 'varnish-http-purge' );
 			$output      = sanitize_text_field( $input );
 		}
 
-		add_settings_error( 'vhp_varnish_header_name', 'varnish-purgeheader', $set_message, $set_type );
+		if ( $set_message ) {
+			add_settings_error( 'vhp_varnish_header_name', 'varnish-purgeheader', $set_message, $set_type );
+		}
+
 		return $output;
 	}
 

--- a/settings.php
+++ b/settings.php
@@ -74,8 +74,8 @@ class VarnishStatus {
 		add_settings_field( 'varnish_ip', __( 'Set Custom IP', 'varnish-http-purge' ), array( &$this, 'settings_ip_callback' ), 'varnish-ip-settings', 'vhp-settings-ip-section' );
 
 		// Purge Headers settings.
-		register_setting( 'vhp-settings-purgeheader', 'vhp_varnish_header_name', array( &$this, 'settings_purgeheaders_name_sanitize' ) );
-		register_setting( 'vhp-settings-purgeheader', 'vhp_varnish_header_value', array( &$this, 'settings_purgeheaders_value_sanitize' ) );
+		register_setting( 'vhp-settings-purgeheader', 'vhp_varnish_extra_purge_header_name', array( &$this, 'settings_purgeheaders_name_sanitize' ) );
+		register_setting( 'vhp-settings-purgeheader', 'vhp_varnish_extra_purge_header_value', array( &$this, 'settings_purgeheaders_value_sanitize' ) );
 		add_settings_section( 'vhp-settings-purgeheader-section', __( 'Purge Headers', 'varnish-http-purge' ), array( &$this, 'options_settings_purgeheaders' ), 'varnish-purgeheader-settings' );
 		add_settings_field( 'varnish_purgeheaders_name', __( 'Set Purge Header Name', 'varnish-http-purge' ), array( &$this, 'settings_purgeheaders_name_callback' ), 'varnish-purgeheader-settings', 'vhp-settings-purgeheader-section' );
 		add_settings_field( 'varnish_purgeheaders_value', __( 'Set Purge Header Value', 'varnish-http-purge' ), array( &$this, 'settings_purgeheaders_value_callback' ), 'varnish-purgeheader-settings', 'vhp-settings-purgeheader-section' );
@@ -464,12 +464,12 @@ sub vcl_recv {
 			$disabled    = true;
 			$header_name = explode( ':', VHP_VARNISH_EXTRA_PURGE_HEADER )[0];
 		} else {
-			$header_name = get_site_option( 'vhp_varnish_header_name' );
+			$header_name = get_site_option( 'vhp_varnish_extra_purge_header_name' );
 		}
 
 		?>
-		<input type="text" id="vhp_varnish_header_name" name="vhp_varnish_header_name" value="<?php echo esc_attr( $header_name ); ?>" size="25" <?php disabled( $disabled, true ); ?> />
-		<label for="vhp_varnish_header_name">&nbsp;
+		<input type="text" id="vhp_varnish_extra_purge_header_name" name="vhp_varnish_extra_purge_header_name" value="<?php echo esc_attr( $header_name ); ?>" size="25" <?php disabled( $disabled, true ); ?> />
+		<label for="vhp_varnish_extra_purge_header_name">&nbsp;
 		<?php
 		if ( $disabled ) {
 			esc_html_e( 'The header has been defined in your wp-config file, so it is not editable in settings.', 'varnish-http-purge' );
@@ -497,15 +497,15 @@ sub vcl_recv {
 			// If the constant is malformed (no value part), fall back to the stored option
 			// so that the field still displays something meaningful.
 			if ( '' === $header_value ) {
-				$header_value = get_site_option( 'vhp_varnish_header_value' );
+				$header_value = get_site_option( 'vhp_varnish_extra_purge_header_value' );
 			}
 		} else {
-			$header_value = get_site_option( 'vhp_varnish_header_value' );
+			$header_value = get_site_option( 'vhp_varnish_extra_purge_header_value' );
 		}
 
 		?>
-		<input type="password" id="vhp_varnish_header_value" name="vhp_varnish_header_value" value="<?php echo esc_attr( $header_value ); ?>" size="25" <?php disabled( $disabled, true ); ?> autocomplete="off" />
-		<label for="vhp_varnish_header_value">&nbsp;
+		<input type="password" id="vhp_varnish_extra_purge_header_value" name="vhp_varnish_extra_purge_header_value" value="<?php echo esc_attr( $header_value ); ?>" size="25" <?php disabled( $disabled, true ); ?> autocomplete="off" />
+		<label for="vhp_varnish_extra_purge_header_value">&nbsp;
 		<?php
 		if ( $disabled ) {
 			esc_html_e( 'The value has been defined in your wp-config file, so it is not editable in settings.', 'varnish-http-purge' );
@@ -528,7 +528,7 @@ sub vcl_recv {
 		}
 
 		if ( $set_message ) {
-			add_settings_error( 'vhp_varnish_header_name', 'varnish-purgeheader', $set_message, $set_type );
+			add_settings_error( 'vhp_varnish_extra_purge_header_name', 'varnish-purgeheader', $set_message, $set_type );
 		}
 
 		return $output;
@@ -549,7 +549,7 @@ sub vcl_recv {
 		}
 
 		if ( $set_message ) {
-			add_settings_error( 'vhp_varnish_header_name', 'varnish-purgeheader', $set_message, $set_type );
+			add_settings_error( 'vhp_varnish_extra_purge_header_value', 'varnish-purgeheader', $set_message, $set_type );
 		}
 
 		return $output;

--- a/settings.php
+++ b/settings.php
@@ -196,12 +196,24 @@ class VarnishStatus {
 			echo '</p>';
 		}
 		?>
-		<details>
-			<summary><?php esc_html_e( 'View VCL Snippet (tags via BAN)', 'varnish-http-purge' ); ?></summary>
+		<div class="vhp-accordion vhp-accordion-vcl">
+			<button type="button" class="vhp-accordion-toggle" aria-expanded="false" aria-controls="vhp-accordion-panel-vcl">
+				<span class="dashicons dashicons-arrow-right" aria-hidden="true"></span>
+				<span class="vhp-accordion-label"><?php esc_html_e( 'View VCL Snippet (tags via BAN)', 'varnish-http-purge' ); ?></span>
+			</button>
+			<div id="vhp-accordion-panel-vcl" class="vhp-accordion-panel" hidden>
 			<pre style="background:#f0f0f0;padding:10px;overflow:auto;">
 sub vcl_recv {
     if (req.method == "PURGE") {
         # ... acl check ...
+        # Optional: validate a control header sent by the plugin (for example
+        # via the VHP_VARNISH_HEADER constant or the "Purge Headers" settings).
+        # Adjust the header name and value to match your environment.
+        #
+        # if (req.http.X-Control-Key != "YOUR_CONTROL_KEY_HERE") {
+        #     return (synth(403, "Forbidden"));
+        # }
+
         if (req.http.X-Purge-Method == "tags" && req.http.X-Cache-Tags-Pattern) {
             ban("obj.http.X-Cache-Tags ~ " + req.http.X-Cache-Tags-Pattern);
             return (synth(200, "Banned by tags pattern"));
@@ -209,7 +221,8 @@ sub vcl_recv {
     }
 }
 			</pre>
-		</details>
+			</div>
+		</div>
 		<?php
 	}
 
@@ -434,7 +447,10 @@ sub vcl_recv {
 	 */
 	public function options_settings_purgeheaders() {
 		?>
-		<p><a name="#configurepurgeheaders"></a><?php esc_html_e( 'Some providers require a control key, token, or Authorization header to accept PURGE requests. You can set the header name and its value here.', 'varnish-http-purge' ); ?></strong></p>
+		<p><a name="#configurepurgeheaders"></a>
+			<strong><?php esc_html_e( 'Advanced:', 'varnish-http-purge' ); ?></strong>
+			<?php esc_html_e( 'Only configure this if your hosting provider or cache service explicitly documents a required control or Authorization header for PURGE requests. If you are not sure, leave these fields empty.', 'varnish-http-purge' ); ?>
+		</p>
 		<?php
 	}
 
@@ -748,11 +764,17 @@ sub vcl_recv {
 				</form>
 
 				<form action="options.php" method="POST" >
-					<?php
-					settings_fields( 'vhp-settings-purgeheader' );
-					do_settings_sections( 'varnish-purgeheader-settings' );
-					submit_button( __( 'Save Purge Header Settings', 'varnish-http-purge' ), 'primary' );
-					?>
+					<?php settings_fields( 'vhp-settings-purgeheader' ); ?>
+					<div class="vhp-accordion vhp-accordion-purgeheaders">
+						<button type="button" class="vhp-accordion-toggle" aria-expanded="false" aria-controls="vhp-accordion-panel-purgeheaders">
+							<span class="dashicons dashicons-arrow-right" aria-hidden="true"></span>
+							<span class="vhp-accordion-label"><?php esc_html_e( 'Advanced: Purge Headers', 'varnish-http-purge' ); ?></span>
+						</button>
+						<div id="vhp-accordion-panel-purgeheaders" class="vhp-accordion-panel" hidden>
+							<?php do_settings_sections( 'varnish-purgeheader-settings' ); ?>
+						</div>
+					</div>
+					<?php submit_button( __( 'Save Purge Header Settings', 'varnish-http-purge' ), 'primary' ); ?>
 				</form>
 				<?php
 			} else {
@@ -763,6 +785,66 @@ sub vcl_recv {
 			}
 			?>
 		</div>
+		<style>
+		.vhp-accordion {
+			margin-top: 1.5em;
+			margin-bottom: 0.5em;
+		}
+		.vhp-accordion .vhp-accordion-toggle {
+			display: inline-flex;
+			align-items: center;
+			gap: 4px;
+			font-size: 14px;
+			font-weight: 600;
+			margin: 0 0 0.5em 0;
+			background: none;
+			border: 0;
+			padding: 0;
+			color: #1d2327;
+			cursor: pointer;
+		}
+		.vhp-accordion .vhp-accordion-toggle:hover {
+			color: #2271b1;
+		}
+		.vhp-accordion .vhp-accordion-toggle .dashicons {
+			font-size: 16px;
+			line-height: 1;
+			transition: transform 0.15s ease-in-out;
+		}
+		.vhp-accordion .vhp-accordion-panel {
+			margin-left: 1.5em;
+		}
+		</style>
+		<script>
+		( function() {
+			document.addEventListener( 'DOMContentLoaded', function() {
+				var accordions = document.querySelectorAll( '.vhp-accordion' );
+				if ( ! accordions.length ) {
+					return;
+				}
+
+				accordions.forEach( function( container ) {
+					var button = container.querySelector( '.vhp-accordion-toggle' );
+					var panel  = container.querySelector( '.vhp-accordion-panel' );
+					if ( ! button || ! panel ) {
+						return;
+					}
+					var icon = button.querySelector( '.dashicons' );
+
+					button.addEventListener( 'click', function() {
+						var expanded = button.getAttribute( 'aria-expanded' ) === 'true';
+						button.setAttribute( 'aria-expanded', expanded ? 'false' : 'true' );
+						panel.hidden = expanded;
+
+						if ( icon ) {
+							icon.classList.toggle( 'dashicons-arrow-right', expanded );
+							icon.classList.toggle( 'dashicons-arrow-down', ! expanded );
+						}
+					} );
+				} );
+			} );
+		} )();
+		</script>
 		<?php
 	}
 

--- a/settings.php
+++ b/settings.php
@@ -55,8 +55,8 @@ class VarnishStatus {
 	public function register_settings() {
 		// Development Mode Settings.
 		register_setting( 'vhp-settings-devmode', 'vhp_varnish_devmode', array( &$this, 'settings_devmode_sanitize' ) );
-		add_settings_section( 'vhp-settings-devmode-section', __( 'Development Mode Settings', 'varnish-http-purge' ), array( &$this, 'options_settings_devmode' ), 'varnish-devmode-settings' );
-		add_settings_field( 'varnish_devmode', __( 'Development Mode', 'varnish-http-purge' ), array( &$this, 'settings_devmode_callback' ), 'varnish-devmode-settings', 'vhp-settings-devmode-section' );
+		add_settings_section( 'vhp-settings-devmode-section', __( 'Development mode settings', 'varnish-http-purge' ), array( &$this, 'options_settings_devmode' ), 'varnish-devmode-settings' );
+		add_settings_field( 'varnish_devmode', __( 'Development mode', 'varnish-http-purge' ), array( &$this, 'settings_devmode_callback' ), 'varnish-devmode-settings', 'vhp-settings-devmode-section' );
 
 		// Purge Method settings (Cache Tags)
 		register_setting( 'vhp-settings-tags', 'vhp_varnish_use_tags', array( &$this, 'settings_tags_sanitize' ) );
@@ -65,13 +65,20 @@ class VarnishStatus {
 
 		// Purge All settings
 		register_setting( 'vhp-settings-maxposts', 'vhp_varnish_max_posts_before_all', array( &$this, 'settings_maxposts_sanitize' ) );
-		add_settings_section( 'vhp-settings-maxposts-section', __( 'Maximum Individual URLs before Full Purge', 'varnish-http-purge' ), array( &$this, 'options_settings_maxposts' ), 'varnish-maxposts-settings' );
-		add_settings_field( 'varnish_maxposts', __( 'Set Max URLs', 'varnish-http-purge' ), array( &$this, 'settings_maxposts_callback' ), 'varnish-maxposts-settings', 'vhp-settings-maxposts-section' );
+		add_settings_section( 'vhp-settings-maxposts-section', __( 'Maximum individual URLs before full purge', 'varnish-http-purge' ), array( &$this, 'options_settings_maxposts' ), 'varnish-maxposts-settings' );
+		add_settings_field( 'varnish_maxposts', __( 'Set max URLs', 'varnish-http-purge' ), array( &$this, 'settings_maxposts_callback' ), 'varnish-maxposts-settings', 'vhp-settings-maxposts-section' );
 
 		// IP Settings.
 		register_setting( 'vhp-settings-ip', 'vhp_varnish_ip', array( &$this, 'settings_ip_sanitize' ) );
-		add_settings_section( 'vhp-settings-ip-section', __( 'Configure Custom IP', 'varnish-http-purge' ), array( &$this, 'options_settings_ip' ), 'varnish-ip-settings' );
-		add_settings_field( 'varnish_ip', __( 'Set Custom IP', 'varnish-http-purge' ), array( &$this, 'settings_ip_callback' ), 'varnish-ip-settings', 'vhp-settings-ip-section' );
+		add_settings_section( 'vhp-settings-ip-section', __( 'Configure custom IP', 'varnish-http-purge' ), array( &$this, 'options_settings_ip' ), 'varnish-ip-settings' );
+		add_settings_field( 'varnish_ip', __( 'Set custom IP', 'varnish-http-purge' ), array( &$this, 'settings_ip_callback' ), 'varnish-ip-settings', 'vhp-settings-ip-section' );
+
+		// Purge All settings
+		register_setting( 'vhp-settings-purgeheader', 'vhp_varnish_header_name', array( &$this, 'settings_purgeheaders_name_sanitize' ) );
+		register_setting( 'vhp-settings-purgeheader', 'vhp_varnish_header_value', array( &$this, 'settings_purgeheaders_value_sanitize' ) );
+		add_settings_section( 'vhp-settings-purgeheader-section', __( 'Purge Headers', 'varnish-http-purge' ), array( &$this, 'options_settings_purgeheaders' ), 'varnish-purgeheader-settings' );
+		add_settings_field( 'varnish_purgeheaders_name', __( 'Set purge header name', 'varnish-http-purge' ), array( &$this, 'settings_purgeheaders_name_callback' ), 'varnish-purgeheader-settings', 'vhp-settings-purgeheader-section' );
+		add_settings_field( 'varnish_purgeheaders_value', __( 'Set purge header value', 'varnish-http-purge' ), array( &$this, 'settings_purgeheaders_value_callback' ), 'varnish-purgeheader-settings', 'vhp-settings-purgeheader-section' );
 	}
 
 	/**
@@ -376,6 +383,7 @@ sub vcl_recv {
 		if ( $disabled ) {
 			esc_html_e( 'A Proxy Cache IP has been defined in your wp-config file, so it is not editable in settings.', 'varnish-http-purge' );
 		} else {
+			echo '<br />';
 			esc_html_e( 'Examples: ', 'varnish-http-purge' );
 			echo '<br /><code>123.45.67.89</code><br /><code>localhost</code><br /><code>12.34.56.78, 23.45.67.89</code>';
 		}
@@ -418,6 +426,97 @@ sub vcl_recv {
 		}
 
 		add_settings_error( 'vhp_varnish_ip', 'varnish-ip', $set_message, $set_type );
+		return $output;
+	}
+
+	/**
+	 * Options Settings - Purge Headers
+	 */
+	public function options_settings_purgeheaders() {
+		?>
+		<p><a name="#configurepurgeheaders"></a><?php esc_html_e( 'Some providers require a control key, token, or Authorization header to accept PURGE requests. You can set the header name and its value here.', 'varnish-http-purge' ); ?></strong></p>
+		<?php
+	}
+
+	/**
+	 * Settings - Purge Headers Name
+	 */
+	public function settings_purgeheaders_name_callback() {
+
+		$disabled = false;
+		if ( defined( 'VHP_VARNISH_HEADER' ) && false !== VHP_VARNISH_HEADER ) {
+			$disabled    = true;
+			$header_name = explode( ':', VHP_VARNISH_HEADER )[0];
+		} else {
+			$header_name = get_site_option( 'vhp_varnish_header_name' );
+		}
+
+		?>
+		<input type="text" id="vph_varnish_header_name" name="vhp_varnish_header_name" value="<?php echo esc_attr( $header_name ); ?>" size="25" <?php disabled( $disabled, true ); ?> />
+		<label for="vph_varnish_header_name">&nbsp;
+		<?php
+		if ( $disabled ) {
+			esc_html_e( 'The header has been defined in your wp-config file, so it is not editable in settings.', 'varnish-http-purge' );
+		}
+		echo '</label>';
+	}
+
+	/**
+	 * Settings - Purge Headers Value
+	 */
+	public function settings_purgeheaders_value_callback() {
+
+		$disabled = false;
+		if ( defined( 'VHP_VARNISH_HEADER' ) && false !== VHP_VARNISH_HEADER ) {
+			$disabled     = true;
+			$header_value = trim( explode( ':', VHP_VARNISH_HEADER )[1] );
+		} else {
+			$header_value = get_site_option( 'vhp_varnish_header_value' );
+		}
+
+		?>
+		<input type="password" id="vph_varnish_header_value" name="vhp_varnish_header_value" value="<?php echo esc_attr( $header_value ); ?>" size="25" <?php disabled( $disabled, true ); ?> autocomplete="off" />
+		<label for="vph_varnish_header_value">&nbsp;
+		<?php
+		if ( $disabled ) {
+			esc_html_e( 'The value has been defined in your wp-config file, so it is not editable in settings.', 'varnish-http-purge' );
+		}
+		echo '</label>';
+	}
+
+	public function settings_purgeheaders_name_sanitize( $input ) {
+		$output      = '';
+		$set_message = __( 'You have entered an invalid header name.', 'varnish-http-purge' );
+		$set_type    = 'error';
+
+		if ( empty( $input ) ) {
+			return;
+		}
+		if ( is_string( $input ) ) {
+			$set_message = __( 'Purge header updated', 'varnish-http-purge' );
+			$set_type    = 'updated';
+			$output      = sanitize_text_field( $input );
+		}
+
+		add_settings_error( 'vhp_varnish_header_name', 'varnish-purgeheader', $set_message, $set_type );
+		return $output;
+	}
+
+	public function settings_purgeheaders_value_sanitize( $input ) {
+		$output      = '';
+		$set_message = __( 'You have entered an invalid header value.', 'varnish-http-purge' );
+		$set_type    = 'error';
+
+		if ( empty( $input ) ) {
+			return;
+		}
+		if ( is_string( $input ) ) {
+			$set_message = __( 'Purge header value updated', 'varnish-http-purge' );
+			$set_type    = 'updated';
+			$output      = sanitize_text_field( $input );
+		}
+
+		add_settings_error( 'vhp_varnish_header_name', 'varnish-purgeheader', $set_message, $set_type );
 		return $output;
 	}
 
@@ -620,7 +719,7 @@ sub vcl_recv {
 				<?php
 					settings_fields( 'vhp-settings-devmode' );
 					do_settings_sections( 'varnish-devmode-settings' );
-					submit_button( __( 'Save Devmode Settings', 'varnish-http-purge' ), 'primary' );
+					submit_button( __( 'Save devmode settings', 'varnish-http-purge' ), 'primary' );
 				?>
 				</form>
 
@@ -636,7 +735,7 @@ sub vcl_recv {
 				<?php
 					settings_fields( 'vhp-settings-maxposts' );
 					do_settings_sections( 'varnish-maxposts-settings' );
-					submit_button( __( 'Save Maxposts Settings', 'varnish-http-purge' ), 'primary' );
+					submit_button( __( 'Save maxposts settings', 'varnish-http-purge' ), 'primary' );
 				?>
 				</form>
 
@@ -644,8 +743,16 @@ sub vcl_recv {
 				<?php
 					settings_fields( 'vhp-settings-ip' );
 					do_settings_sections( 'varnish-ip-settings' );
-					submit_button( __( 'Save IP Settings', 'varnish-http-purge' ), 'secondary' );
+					submit_button( __( 'Save IP settings', 'varnish-http-purge' ), 'secondary' );
 				?>
+				</form>
+
+				<form action="options.php" method="POST" >
+					<?php
+					settings_fields( 'vhp-settings-purgeheader' );
+					do_settings_sections( 'varnish-purgeheader-settings' );
+					submit_button( __( 'Save purge header settings', 'varnish-http-purge' ), 'primary' );
+					?>
 				</form>
 				<?php
 			} else {

--- a/settings.php
+++ b/settings.php
@@ -207,7 +207,7 @@ sub vcl_recv {
     if (req.method == "PURGE") {
         # ... acl check ...
         # Optional: validate a control header sent by the plugin (for example
-        # via the VHP_VARNISH_HEADER constant or the "Purge Headers" settings).
+        # via the VHP_VARNISH_EXTRA_PURGE_HEADER constant or the "Purge Headers" settings).
         # Adjust the header name and value to match your environment.
         #
         # if (req.http.X-Control-Key != "YOUR_CONTROL_KEY_HERE") {
@@ -460,9 +460,9 @@ sub vcl_recv {
 	public function settings_purgeheaders_name_callback() {
 
 		$disabled = false;
-		if ( defined( 'VHP_VARNISH_HEADER' ) && false !== VHP_VARNISH_HEADER ) {
+		if ( defined( 'VHP_VARNISH_EXTRA_PURGE_HEADER' ) && false !== VHP_VARNISH_EXTRA_PURGE_HEADER ) {
 			$disabled    = true;
-			$header_name = explode( ':', VHP_VARNISH_HEADER )[0];
+			$header_name = explode( ':', VHP_VARNISH_EXTRA_PURGE_HEADER )[0];
 		} else {
 			$header_name = get_site_option( 'vhp_varnish_header_name' );
 		}
@@ -483,9 +483,9 @@ sub vcl_recv {
 	public function settings_purgeheaders_value_callback() {
 
 		$disabled = false;
-		if ( defined( 'VHP_VARNISH_HEADER' ) && false !== VHP_VARNISH_HEADER ) {
+		if ( defined( 'VHP_VARNISH_EXTRA_PURGE_HEADER' ) && false !== VHP_VARNISH_EXTRA_PURGE_HEADER ) {
 			$disabled     = true;
-			$header_value = trim( explode( ':', VHP_VARNISH_HEADER )[1] );
+			$header_value = trim( explode( ':', VHP_VARNISH_EXTRA_PURGE_HEADER )[1] );
 		} else {
 			$header_value = get_site_option( 'vhp_varnish_header_value' );
 		}

--- a/tests/mu-plugins/test-control.php
+++ b/tests/mu-plugins/test-control.php
@@ -221,7 +221,7 @@ add_action( 'rest_api_init', function() {
         'permission_callback' => '__return_true',
     ) );
 
-    // Configure custom purge header name/value for tests.
+            // Configure custom purge header name/value for tests.
     register_rest_route( 'test/v1', '/purge-header-options', array(
         'methods' => 'POST',
         'callback' => function( WP_REST_Request $req ) {
@@ -230,25 +230,25 @@ add_action( 'rest_api_init', function() {
 
             // When either value is not a string, treat this as a reset to defaults.
             if ( ! is_string( $name ) || ! is_string( $value ) ) {
-                delete_site_option( 'vhp_varnish_header_name' );
-                delete_site_option( 'vhp_varnish_header_value' );
+                        delete_site_option( 'vhp_varnish_extra_purge_header_name' );
+                        delete_site_option( 'vhp_varnish_extra_purge_header_value' );
             } else {
                 $name  = trim( $name );
                 $value = trim( $value );
 
                 if ( '' === $name || '' === $value ) {
-                    delete_site_option( 'vhp_varnish_header_name' );
-                    delete_site_option( 'vhp_varnish_header_value' );
+                            delete_site_option( 'vhp_varnish_extra_purge_header_name' );
+                            delete_site_option( 'vhp_varnish_extra_purge_header_value' );
                 } else {
-                    update_site_option( 'vhp_varnish_header_name', sanitize_text_field( $name ) );
-                    update_site_option( 'vhp_varnish_header_value', sanitize_text_field( $value ) );
+                            update_site_option( 'vhp_varnish_extra_purge_header_name', sanitize_text_field( $name ) );
+                            update_site_option( 'vhp_varnish_extra_purge_header_value', sanitize_text_field( $value ) );
                 }
             }
 
             return array(
                 'ok'    => true,
-                'name'  => get_site_option( 'vhp_varnish_header_name' ),
-                'value' => get_site_option( 'vhp_varnish_header_value' ),
+                        'name'  => get_site_option( 'vhp_varnish_extra_purge_header_name' ),
+                        'value' => get_site_option( 'vhp_varnish_extra_purge_header_value' ),
             );
         },
         'permission_callback' => '__return_true',

--- a/tests/mu-plugins/test-control.php
+++ b/tests/mu-plugins/test-control.php
@@ -220,6 +220,75 @@ add_action( 'rest_api_init', function() {
         },
         'permission_callback' => '__return_true',
     ) );
+
+    // Configure custom purge header name/value for tests.
+    register_rest_route( 'test/v1', '/purge-header-options', array(
+        'methods' => 'POST',
+        'callback' => function( WP_REST_Request $req ) {
+            $name  = $req->get_param( 'name' );
+            $value = $req->get_param( 'value' );
+
+            // When either value is not a string, treat this as a reset to defaults.
+            if ( ! is_string( $name ) || ! is_string( $value ) ) {
+                delete_site_option( 'vhp_varnish_header_name' );
+                delete_site_option( 'vhp_varnish_header_value' );
+            } else {
+                $name  = trim( $name );
+                $value = trim( $value );
+
+                if ( '' === $name || '' === $value ) {
+                    delete_site_option( 'vhp_varnish_header_name' );
+                    delete_site_option( 'vhp_varnish_header_value' );
+                } else {
+                    update_site_option( 'vhp_varnish_header_name', sanitize_text_field( $name ) );
+                    update_site_option( 'vhp_varnish_header_value', sanitize_text_field( $value ) );
+                }
+            }
+
+            return array(
+                'ok'    => true,
+                'name'  => get_site_option( 'vhp_varnish_header_name' ),
+                'value' => get_site_option( 'vhp_varnish_header_value' ),
+            );
+        },
+        'permission_callback' => '__return_true',
+    ) );
+
+    // Inspect headers that would be sent with a PURGE request.
+    register_rest_route( 'test/v1', '/purge-headers', array(
+        'methods' => 'POST',
+        'callback' => function( WP_REST_Request $req ) {
+            $url = $req->get_param( 'url' );
+            if ( ! is_string( $url ) || '' === $url ) {
+                $url = home_url( '/' );
+            }
+
+            $captured = null;
+            $callback = function( $headers ) use ( &$captured ) {
+                $captured = $headers;
+                return $headers;
+            };
+
+            add_filter( 'varnish_http_purge_headers', $callback, 9999 );
+
+            if ( class_exists( 'VarnishPurger' ) ) {
+                VarnishPurger::purge_url( esc_url_raw( $url ) );
+            }
+
+            remove_filter( 'varnish_http_purge_headers', $callback, 9999 );
+
+            if ( ! is_array( $captured ) ) {
+                return new WP_Error( 'no_headers', 'Failed to capture purge headers', array( 'status' => 500 ) );
+            }
+
+            return array(
+                'ok'      => true,
+                'url'     => $url,
+                'headers' => $captured,
+            );
+        },
+        'permission_callback' => '__return_true',
+    ) );
 } );
 
 // Keep tag-pattern headers deliberately small in tests to exercise batching logic.

--- a/tests/test_purge_headers.py
+++ b/tests/test_purge_headers.py
@@ -56,8 +56,8 @@ def test_default_purge_headers_have_no_custom_control_key():
 def test_purge_headers_respect_site_options_when_no_constant():
     """
     When a header name/value is configured via site options and no
-    VHP_VARNISH_HEADER constant is defined, the plugin should include that
-    header on PURGE requests.
+    VHP_VARNISH_EXTRA_PURGE_HEADER constant is defined, the plugin should
+    include that header on PURGE requests.
     """
     # Configure a simple control key header via the MU helper.
     name = "X-Control-Key"

--- a/tests/test_purge_headers.py
+++ b/tests/test_purge_headers.py
@@ -1,0 +1,75 @@
+import requests
+
+from conftest import API_BASE, _host_headers
+
+
+def _set_purge_header(name: str | None = None, value: str | None = None) -> dict:
+    """
+    Helper to configure or reset purge header options via the test MU plugin.
+
+    Passing empty strings (""), or omitting parameters, resets the options.
+    """
+    payload: dict = {}
+    if name is not None:
+        payload["name"] = name
+    if value is not None:
+        payload["value"] = value
+    r = requests.post(f"{API_BASE}/purge-header-options", json=payload, headers=_host_headers())
+    r.raise_for_status()
+    return r.json()
+
+
+def _get_purge_headers(url: str | None = None) -> dict:
+    """
+    Ask WordPress (via the MU plugin) to perform a PURGE and report the headers
+    that the plugin sent with the request.
+    """
+    payload: dict = {}
+    if url is not None:
+        payload["url"] = url
+    r = requests.post(f"{API_BASE}/purge-headers", json=payload, headers=_host_headers())
+    r.raise_for_status()
+    data = r.json()
+    return data.get("headers", {})
+
+
+def test_default_purge_headers_have_no_custom_control_key():
+    """
+    By default there should be no custom control/auth header; only the core
+    headers added by the plugin (host + X-Purge-Method).
+    """
+    # Ensure any prior test configuration is cleared.
+    _set_purge_header("", "")
+
+    headers = _get_purge_headers()
+    assert headers, "Expected to capture some PURGE headers"
+
+    # Sanity: we always send host + X-Purge-Method.
+    assert headers.get("host") is not None
+    assert headers.get("X-Purge-Method") in {"default", "regex"}
+
+    # With no options set, there should be no extra custom header keys.
+    custom_keys = [k for k in headers.keys() if k not in {"host", "X-Purge-Method"}]
+    assert custom_keys == []
+
+
+def test_purge_headers_respect_site_options_when_no_constant():
+    """
+    When a header name/value is configured via site options and no
+    VHP_VARNISH_HEADER constant is defined, the plugin should include that
+    header on PURGE requests.
+    """
+    # Configure a simple control key header via the MU helper.
+    name = "X-Control-Key"
+    value = "TEST_SECRET_VALUE"
+    cfg = _set_purge_header(name, value)
+    assert cfg["name"] == name
+    assert cfg["value"] == value
+
+    headers = _get_purge_headers()
+    assert headers.get("X-Control-Key") == value
+
+    # Clean up so other tests see the default behaviour.
+    _set_purge_header("", "")
+
+

--- a/uninstall.php
+++ b/uninstall.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) && ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 // Delete site options.
 delete_site_option( 'vhp_varnish_url' );
 delete_site_option( 'vhp_varnish_ip' );
-delete_site_option( 'vhp_varnish_header_name' );
-delete_site_option( 'vhp_varnish_header_value' );
+delete_site_option( 'vhp_varnish_extra_purge_header_name' );
+delete_site_option( 'vhp_varnish_extra_purge_header_value' );
 delete_site_option( 'vhp_varnish_devmode' );
 delete_site_option( 'vhp_varnish_max_posts_before_all' );

--- a/uninstall.php
+++ b/uninstall.php
@@ -11,5 +11,7 @@ if ( ! defined( 'ABSPATH' ) && ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 // Delete site options.
 delete_site_option( 'vhp_varnish_url' );
 delete_site_option( 'vhp_varnish_ip' );
+delete_site_option( 'vhp_varnish_header_name' );
+delete_site_option( 'vhp_varnish_header_value' );
 delete_site_option( 'vhp_varnish_devmode' );
 delete_site_option( 'vhp_varnish_max_posts_before_all' );

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -816,7 +816,7 @@ class VarnishPurger {
 			 */
 			$headers = apply_filters(
 				'varnish_http_purge_headers',
-				$default_headers,
+				$default_headers
 			);
 
 			// Send response.
@@ -1369,6 +1369,17 @@ if ( ! class_exists( 'VarnishStatus' ) ) {
 	if ( ! is_network_admin() ) {
 		require_once 'settings.php';
 	}
+
+	/**
+	 * In the test stack, a small MU plugin (`test-control.php`) under
+	 * `wp-content/mu-plugins` registers helper REST endpoints that the
+	 * Python/pytest suite relies on. Some environments may not auto-load
+	 * MU plugins for HTTP requests (for example when bootstrapped in a
+	 * minimal context), so we defensively include it here when present.
+	 *
+	 * This is a no-op on normal installations where the file does not
+	 * exist, and safe when it does thanks to include_once.
+	 */
 	require_once 'debug.php';
 	require_once 'health-check.php';
 	require_once 'varnish-tags.php';

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -71,7 +71,7 @@ class VarnishPurger {
 		defined( 'VHP_VARNISH_IP' ) || define( 'VHP_VARNISH_IP', false );
 		defined( 'VHP_DEVMODE' ) || define( 'VHP_DEVMODE', false );
 		defined( 'VHP_DOMAINS' ) || define( 'VHP_DOMAINS', false );
-		defined( 'VHP_VARNISH_HEADER' ) || define( 'VHP_VARNISH_HEADER', false );
+		defined( 'VHP_VARNISH_EXTRA_PURGE_HEADER' ) || define( 'VHP_VARNISH_EXTRA_PURGE_HEADER', false );
 		defined( 'VHP_EXCLUDED_POST_STATUSES' ) || define( 'VHP_EXCLUDED_POST_STATUSES', false );
 
 		add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( &$this, 'settings_link' ) );
@@ -793,9 +793,9 @@ class VarnishPurger {
 				'host'           => $host_headers,
 				'X-Purge-Method' => $x_purge_method,
 			);
-			if ( VHP_VARNISH_HEADER && strpos( VHP_VARNISH_HEADER, ':' ) !== false ) {
+			if ( VHP_VARNISH_EXTRA_PURGE_HEADER && strpos( VHP_VARNISH_EXTRA_PURGE_HEADER, ':' ) !== false ) {
 				// If this is set, extract name/value.
-				$header_parts        = explode( ':', VHP_VARNISH_HEADER, 2 );
+				$header_parts        = explode( ':', VHP_VARNISH_EXTRA_PURGE_HEADER, 2 );
 				$custom_header_name  = trim( $header_parts[0] );
 				$custom_header_value = ( isset( $header_parts[1] ) ) ? trim( $header_parts[1] ) : '';
 				if ( ! empty( $custom_header_name ) && ! empty( $custom_header_value ) ) {

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -801,9 +801,9 @@ class VarnishPurger {
 				if ( ! empty( $custom_header_name ) && ! empty( $custom_header_value ) ) {
 					$default_headers[ $custom_header_name ] = $custom_header_value;
 				}
-			} elseif ( get_site_option( 'vhp_varnish_header_value' ) && get_site_option( 'vhp_varnish_header_name' ) ) {
-				$custom_header_name  = trim( get_site_option( 'vhp_varnish_header_name' ) );
-				$custom_header_value = trim( get_site_option( 'vhp_varnish_header_value' ) );
+			} elseif ( get_site_option( 'vhp_varnish_extra_purge_header_value' ) && get_site_option( 'vhp_varnish_extra_purge_header_name' ) ) {
+				$custom_header_name  = trim( get_site_option( 'vhp_varnish_extra_purge_header_name' ) );
+				$custom_header_value = trim( get_site_option( 'vhp_varnish_extra_purge_header_value' ) );
 				if ( ! empty( $custom_header_name ) && ! empty( $custom_header_value ) ) {
 					$default_headers[ $custom_header_name ] = $custom_header_value;
 				}

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -73,6 +73,8 @@ class VarnishPurger {
 		defined( 'VHP_DOMAINS' ) || define( 'VHP_DOMAINS', false );
 		defined( 'VHP_EXCLUDED_POST_STATUSES' ) || define( 'VHP_EXCLUDED_POST_STATUSES', false );
 
+		add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( &$this, 'settings_link' ) );
+
 		// Development mode defaults to off.
 		self::$devmode = array(
 			'active' => false,
@@ -271,6 +273,15 @@ class VarnishPurger {
 	public function admin_message_devmode() {
 		$message = ( VarnishDebug::devmode_check() ) ? __( 'Development Mode activated for the next 24 hours.', 'varnish-http-purge' ) : __( 'Development Mode deactivated.', 'varnish-http-purge' );
 		echo '<div id="message" class="notice notice-success fade is-dismissible"><p><strong>' . wp_kses_post( $message ) . '</strong></p></div>';
+	}
+
+	/**
+	 * Add settings link on plugin list
+	 */
+	public function settings_link( $links ) {
+		$settings_link = '<a href="admin.php?page=varnish-page">' . __( 'Settings', 'varnish-http-purge' ) . '</a>';
+		array_unshift( $links, $settings_link );
+		return $links;
 	}
 
 	/**

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -71,6 +71,7 @@ class VarnishPurger {
 		defined( 'VHP_VARNISH_IP' ) || define( 'VHP_VARNISH_IP', false );
 		defined( 'VHP_DEVMODE' ) || define( 'VHP_DEVMODE', false );
 		defined( 'VHP_DOMAINS' ) || define( 'VHP_DOMAINS', false );
+		defined( 'VHP_VARNISH_HEADER' ) || define( 'VHP_VARNISH_HEADER', false );
 		defined( 'VHP_EXCLUDED_POST_STATUSES' ) || define( 'VHP_EXCLUDED_POST_STATUSES', false );
 
 		add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( &$this, 'settings_link' ) );
@@ -788,6 +789,26 @@ class VarnishPurger {
 			 */
 			$purgeme = apply_filters( 'vhp_purgeme_path', $purgeme, $schema, $one_host, $path, $pregex, $p );
 
+			$default_headers = array(
+				'host'           => $host_headers,
+				'X-Purge-Method' => $x_purge_method,
+			);
+			if ( VHP_VARNISH_HEADER && strpos( VHP_VARNISH_HEADER, ':' ) !== false ) {
+				// If this is set, extract name/value.
+				$header_parts        = explode( ':', VHP_VARNISH_HEADER, 2 );
+				$custom_header_name  = trim( $header_parts[0] );
+				$custom_header_value = ( isset( $header_parts[1] ) ) ? trim( $header_parts[1] ) : '';
+				if ( ! empty( $custom_header_name ) && ! empty( $custom_header_value ) ) {
+					$default_headers[ $custom_header_name ] = $custom_header_value;
+				}
+			} elseif ( get_site_option( 'vhp_varnish_header_value' ) && get_site_option( 'vhp_varnish_header_name' ) ) {
+				$custom_header_name  = trim( get_site_option( 'vhp_varnish_header_name' ) );
+				$custom_header_value = trim( get_site_option( 'vhp_varnish_header_value' ) );
+				if ( ! empty( $custom_header_name ) && ! empty( $custom_header_value ) ) {
+					$default_headers[ $custom_header_name ] = $custom_header_value;
+				}
+			}
+
 			/**
 			 * Filters the HTTP headers to send with a PURGE request.
 			 *
@@ -795,10 +816,7 @@ class VarnishPurger {
 			 */
 			$headers = apply_filters(
 				'varnish_http_purge_headers',
-				array(
-					'host'           => $host_headers,
-					'X-Purge-Method' => $x_purge_method,
-				)
+				$default_headers,
 			);
 
 			// Send response.


### PR DESCRIPTION
Hey,

This PR adds a way to set a custom header via wp-admin or via a constant.
Personal need for this to be via wp-admin is that I'm not looking to update 100 repos with filters as I'm moving a lot of projects to a new hosting setup that requires this 😅 

I also added a settings_link in the plugin list and changed some copy to be consistent, but if that's not desired I will revert those changes

If there's any questions or feedback, let me know!

###### wow wordpress' way of adding settings is very ass

