### PR TITLE
Release 5.9.1: WP 7.0 compat, PHP 7.4 minimum, Plugin Check CI

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -12,16 +12,27 @@ bitbucket-pipelines.yml
 
 # IDE and editor files
 .cursor
+.claude
 .editorconfig
 .vscode
 .idea
 *.sublime-project
 *.sublime-workspace
 
+# Browser/automation scratch
+.playwright-cli
+.playwright-mcp
+.pytest_cache
+
 # Development tooling
 .pre-commit-config.yaml
 Makefile
 todo.txt
+TODO.md
+TODO2.md
+CLAUDE.md
+AGENTS.md
+debugger
 
 # PHP static analysis and linting
 phpstan.neon

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -213,10 +213,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Stage a clean copy that mirrors what 10up/action-wordpress-plugin-deploy
+      # ships to WP.org (filtered by .distignore). Plugin Check then runs against
+      # that — same files real users get — instead of the raw git checkout, which
+      # includes .github/, tests/, dev tooling, etc.
+      - name: Prepare dist build for Plugin Check
+        run: |
+          mkdir -p ../dist
+          rsync -a \
+            --exclude-from='.distignore' \
+            --exclude='.git/' \
+            ./ ../dist/
+
       - name: Run Plugin Check
         uses: WordPress/plugin-check-action@v1
         with:
-          build-dir: './'
+          build-dir: '../dist'
 
   i18n:
     name: Internationalization

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -206,6 +206,18 @@ jobs:
             exit 1
           fi
 
+  plugin-check:
+    name: WordPress Plugin Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Plugin Check
+        uses: WordPress/plugin-check-action@v1
+        with:
+          build-dir: './'
+
   i18n:
     name: Internationalization
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ CLAUDE.md
 .playwright-mcp/
 TODO.md
 TODO2.md
+# Browser/automation scratch
+.playwright-cli/
+.playwright-mcp/
+.pytest_cache/
+.claude/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: up down build setup test tests logs clean pytest teststack lint phpcs phpcbf phpstan php-compat validate security check-all
+.PHONY: up down build setup test tests logs clean pytest teststack lint phpcs phpcbf phpstan php-compat validate security check-all plugin-check
 
 # ============================================================================
 # Linting and Static Analysis
@@ -108,6 +108,11 @@ security:
 	else \
 		exit 1; \
 	fi
+
+plugin-check:
+	@echo "Running WordPress Plugin Check (requires the test stack to be up)..."
+	@cd tests && docker compose run --rm wpcli plugin install plugin-check --activate >/dev/null
+	@cd tests && docker compose run --rm wpcli plugin check varnish-http-purge --fields=code,type,message --format=table
 
 changelog:
 	@echo "Checking changelog..."

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 ## CHANGELOG
 
+= 5.9.1 =
+* May 2026
+* Update: Tested up to WordPress 7.0
+* Update: `Requires PHP` bumped from 5.6 to 7.4 to match WordPress 7.0's PHP floor. Sites on PHP < 7.4 will not see this update.
+
 = 5.9.0 =
 * April 2026
 * New: NGINX cache-purge backend support -- uses literal * instead of .* regex for wildcard purges

--- a/health-check.php
+++ b/health-check.php
@@ -90,7 +90,7 @@ function vhp_site_status_caching_test() {
 		$result['actions']     = sprintf(
 			'<p><a href="%s">%s</a></p>',
 			esc_url( admin_url( 'admin.php?page=varnish-page' ) ),
-			__( 'Enable Caching' )
+			__( 'Enable Caching', 'varnish-http-purge' )
 		);
 	} elseif ( ! empty( $debug_results ) && '' !== $debug_results ) {
 		$count = count( $debug_results );

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: Ipstenu, mikeschroder, techpriester, danielbachhuber, dvershinin
 Tags: proxy, purge, cache, varnish, nginx
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 5.9.0
-Requires PHP: 5.6
+Stable tag: 5.9.1
+Requires PHP: 7.4
 License: Apache License 2.0
 License URI: https://www.apache.org/licenses/LICENSE-2.0
 
@@ -461,6 +461,10 @@ add_filter( 'varnish_http_purge_x_varnish_header_name', 'change_varnish_header' 
 </code>
 
 == Changelog ==
+
+= 5.9.1 (2026-05) =
+* Update: Tested up to WordPress 7.0
+* Update: `Requires PHP` bumped from 5.6 to 7.4 to match WordPress 7.0's PHP floor. Sites on PHP < 7.4 will not see this update.
 
 = 5.8.1 (2026-03) =
 * New: Regex purge URLs for category, tag, and blog listing pages to properly invalidate paginated archive pages (e.g., /category/news/page/2)

--- a/settings.php
+++ b/settings.php
@@ -2058,7 +2058,7 @@ sub vcl_recv {
 		global $current_screen;
 
 		if ( ! empty( $current_screen->parent_base ) && strpos( $current_screen->parent_base, 'varnish-page' ) !== false ) {
-			$review_url       = 'https://wordpress.org/support/plugin/varnish-http-purge/reviews/?filter=5#new-post';
+			$review_url       = 'https://wordpress.org/support/plugin/varnish-http-purge/reviews/#new-post';
 			$getpagespeed_url = 'https://www.getpagespeed.com/';
 			$footer_text      = sprintf(
 				wp_kses(

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -30,6 +30,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Purge Class
  *

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -3,9 +3,10 @@
  * Plugin Name: Proxy Cache Purge
  * Plugin URI: https://github.com/dvershinin/varnish-http-purge
  * Description: Automatically empty cached pages when content on your site is modified.
- * Version: 5.9.0
+ * Version: 5.9.1
  * Requires at least: 5.0
- * Requires PHP: 5.6
+ * Tested up to: 7.0
+ * Requires PHP: 7.4
  * Author: Mika Epstein, Danila Vershinin
  * Author URI: https://halfelf.org/
  * License: Apache License 2.0
@@ -40,7 +41,7 @@ class VarnishPurger {
 	 * Version Number
 	 * @var string
 	 */
-	public static $version = '5.9.0';
+	public static $version = '5.9.1';
 
 	/**
 	 * List of URLs to be purged

--- a/varnish-tags.php
+++ b/varnish-tags.php
@@ -6,6 +6,8 @@
  * @since 5.4.0
  */
 
+defined( 'ABSPATH' ) || exit;
+
 class VarnishTags {
 
 	/**


### PR DESCRIPTION
## Summary
- Tested up to: 7.0 (was 6.9). Today's cron already bumped trunk's readme; this PR mirrors it into the plugin header and the changelog.
- Requires PHP: 7.4 (was 5.6). Aligns with WordPress 7.0's PHP floor. Users on PHP < 7.4 simply won't see this update.
- Adds a `WordPress Plugin Check` GitHub Actions job (via `WordPress/plugin-check-action@v1`) so we catch any future Plugin Check errors before WP.org's auto-scanner does.
- Adds a `make plugin-check` target for local runs through the existing test stack.

## Test plan
- [ ] Lint workflow runs end-to-end on this PR (phpcs, phpstan, php-compatibility against 7.4, plugin-headers, text-files, plugin-check, i18n) — all green.
- [ ] Plugin Check produces no `ERROR` rows. WARN rows acceptable.
- [ ] After merge + tag `5.9.1`: deploy.yml runs the existing test suite, then 10up/action-wordpress-plugin-deploy pushes to WP.org SVN. WP.org listing shows 5.9.1 with PHP 7.4 minimum.