### PR TITLE
CI: harden lint workflow against transient packagist/network flakes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,10 +21,17 @@ jobs:
           tools: phpcs
           extensions: mbstring
 
+      # Retry around the composer call: packagist.org occasionally has DNS /
+      # connect-timeout flakes that fail CI through no fault of the change.
       - name: Install WordPress Coding Standards
-        run: |
-          composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-          composer global require --dev wp-coding-standards/wpcs:"^3.0" dealerdirect/phpcodesniffer-composer-installer
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: |
+            composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+            composer global require --dev wp-coding-standards/wpcs:"^3.0" dealerdirect/phpcodesniffer-composer-installer
 
       - name: Run PHPCS
         run: phpcs
@@ -44,7 +51,12 @@ jobs:
           extensions: mbstring
 
       - name: Install WordPress stubs
-        run: composer global require php-stubs/wordpress-stubs
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: composer global require php-stubs/wordpress-stubs
 
       - name: Run PHPStan
         run: phpstan analyse --no-progress --error-format=github
@@ -64,9 +76,14 @@ jobs:
           extensions: mbstring
 
       - name: Install PHPCompatibility
-        run: |
-          composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-          composer global require --dev phpcompatibility/php-compatibility dealerdirect/phpcodesniffer-composer-installer
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: |
+            composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+            composer global require --dev phpcompatibility/php-compatibility dealerdirect/phpcodesniffer-composer-installer
 
       - name: Extract declared PHP version from readme.txt
         id: php_version
@@ -229,8 +246,14 @@ jobs:
             --exclude='.git/' \
             ./ ../varnish-http-purge-dist/varnish-http-purge/
 
-      - name: Run Plugin Check
+      # The plugin-check-action builds its own Docker image + runs composer
+      # against packagist; that's been the source of transient CI failures
+      # (packagist DNS / connect timeouts). Run the action up to twice:
+      # `continue-on-error` on the first try, then a real retry if it failed.
+      - name: Run Plugin Check (attempt 1)
+        id: plugin_check_first
         uses: WordPress/plugin-check-action@v1
+        continue-on-error: true
         with:
           build-dir: '../varnish-http-purge-dist/varnish-http-purge'
           # Suppress only what we CAN'T fix without breaking the public API:
@@ -246,6 +269,13 @@ jobs:
           # is intentionally NOT suppressed — those should be fixed in code.
           ignore-codes: 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound'
 
+      - name: Run Plugin Check (retry on transient failure)
+        if: steps.plugin_check_first.outcome == 'failure'
+        uses: WordPress/plugin-check-action@v1
+        with:
+          build-dir: '../varnish-http-purge-dist/varnish-http-purge'
+          ignore-codes: 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound'
+
   i18n:
     name: Internationalization
     runs-on: ubuntu-latest
@@ -259,10 +289,15 @@ jobs:
           php-version: '8.2'
 
       - name: Install WP-CLI
-        run: |
-          curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-          chmod +x wp-cli.phar
-          sudo mv wp-cli.phar /usr/local/bin/wp
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 3
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            curl --fail --location -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+            chmod +x wp-cli.phar
+            sudo mv wp-cli.phar /usr/local/bin/wp
 
       - name: Check for i18n issues
         run: |


### PR DESCRIPTION
## Summary
Today's CI failed twice from `curl error 28` against `packagist.org` and `raw.githubusercontent.com`. Each failure was unrelated to the code change but still blocked the PR. Wrap the network-dependent install steps so the workflow recovers on its own.

## Changes
- 3 `composer global require` steps in `phpcs`, `phpstan`, `php-compatibility` jobs → wrapped in `nick-fields/retry@v3` (3 attempts, 15s wait between).
- `i18n` job's `curl -O wp-cli.phar` → same retry wrapper (3 attempts, 10s wait), plus `--fail --location` to surface HTTP errors.
- `plugin-check` job → first run with `continue-on-error: true`, then a conditional re-invocation if the first failed. Plugin Check action can't be wrapped by the retry action (only shell commands), so the fallback step is the cleanest workaround.

A real code regression still fails on the second attempt; only transient infra flakes get absorbed.

## Test plan
- [ ] All Lint jobs pass green on this PR.
- [ ] Workflow runs end-to-end in normal time (~2-3 min per job).