### PR TITLE
Fix incorrect @param docblocks + add PHPDoc-type CI linter (5.9.2)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -36,7 +36,9 @@ debugger
 
 # PHP static analysis and linting
 phpstan.neon
+phpstan-phpdoc.neon
 phpstan-bootstrap.php
+build
 phpcs.xml
 phpcs.xml.dist
 phpunit.xml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,6 +61,42 @@ jobs:
       - name: Run PHPStan
         run: phpstan analyse --no-progress --error-format=github
 
+  phpstan-phpdoc:
+    name: PHPStan PHPDoc Types
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: phpstan
+          extensions: mbstring
+
+      - name: Install WordPress stubs
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: composer global require php-stubs/wordpress-stubs
+
+      # The PHPDoc linter scans the WordPress stub file so it knows the real
+      # signatures of WP functions (get_permalink(), wp_parse_url(), ...). Symlink
+      # it into build/ where phpstan-phpdoc.neon expects it.
+      - name: Wire WordPress stubs into build/
+        run: |
+          mkdir -p build
+          ln -sf "$(composer global config home)/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php" build/wordpress-stubs.php
+
+      # Catches @param/@return types that disagree with reality (e.g. a docblock
+      # claiming `array` for a value every caller passes as a string). Scoped +
+      # level 5; see phpstan-phpdoc.neon. 1G because scanning the WP stubs is heavy.
+      - name: Run PHPStan (PHPDoc types)
+        run: phpstan analyse -c phpstan-phpdoc.neon --no-progress --error-format=github --memory-limit=1G
+
   php-compatibility:
     name: PHP Compatibility
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .htaccess
 wp-config.php
+# PHPStan PHPDoc linter: local symlink to the global wordpress-stubs file
+/build/
 wp-content/uploads/
 wp-content/blogs.dir/
 wp-content/upgrade/

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 SHELL := /bin/bash
 
-.PHONY: up down build setup test tests logs clean pytest teststack lint phpcs phpcbf phpstan php-compat validate security check-all plugin-check
+.PHONY: up down build setup test tests logs clean pytest teststack lint phpcs phpcbf phpstan phpstan-phpdoc php-compat validate security check-all plugin-check
 
 # ============================================================================
 # Linting and Static Analysis
 # ============================================================================
 
-lint: phpcs phpstan
+lint: phpcs phpstan phpstan-phpdoc
 	@echo "All linting checks passed!"
 
 # Run ALL checks (like CI does)
@@ -40,6 +40,24 @@ phpstan:
 	@echo "Running PHPStan..."
 	@if command -v phpstan &> /dev/null; then \
 		phpstan analyse --no-progress --memory-limit=512M; \
+	else \
+		echo "phpstan not installed. Install with: composer global require phpstan/phpstan"; \
+	fi
+
+# PHPDoc-type linter: catches @param/@return types that disagree with reality
+# (e.g. `@param array $url` on a method whose callers pass a string). Loads the
+# WordPress function stubs and runs at level 5 so the mismatch becomes an error.
+# See phpstan-phpdoc.neon for the rationale and scope.
+phpstan-phpdoc:
+	@echo "Running PHPStan PHPDoc-type linter..."
+	@if command -v phpstan &> /dev/null; then \
+		stub="$$(composer global config home 2>/dev/null)/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php"; \
+		if [ ! -f "$$stub" ]; then \
+			echo "WordPress stubs missing. Install with: composer global require php-stubs/wordpress-stubs"; \
+			exit 1; \
+		fi; \
+		mkdir -p build && ln -sf "$$stub" build/wordpress-stubs.php; \
+		phpstan analyse -c phpstan-phpdoc.neon --no-progress --memory-limit=1G; \
 	else \
 		echo "phpstan not installed. Install with: composer global require phpstan/phpstan"; \
 	fi

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 ## CHANGELOG
 
+= 5.9.2 =
+* May 2026
+* Fix: Corrected @param/@return docblock types on purge_post(), purge_url(), generate_urls(), check_upgrades(), and nocache_cssjs() so they match the values actually passed and returned. Removes false IDE and static-analysis warnings reported by Sjoerd Boerrigter. No runtime behavior changes.
+* New: CI now lints PHPDoc parameter/return types against real WordPress function signatures (PHPStan + WP stubs), so this class of docblock drift is caught automatically.
+
 = 5.9.1 =
 * May 2026
 * Update: Tested up to WordPress 7.0

--- a/debug.php
+++ b/debug.php
@@ -82,7 +82,7 @@ class VarnishDebug {
 	 * @access public
 	 * @static
 	 * @param mixed $src - URL of CSS or JS file.
-	 * @return url
+	 * @return string
 	 * @since 4.6.0
 	 */
 	public static function nocache_cssjs( $src ) {

--- a/phpstan-phpdoc.neon
+++ b/phpstan-phpdoc.neon
@@ -1,0 +1,46 @@
+# PHPDoc-type linter (separate from the main phpstan.neon).
+#
+# Purpose: catch @param / @return type annotations that disagree with reality,
+# e.g. `@param array $url` on purge_url() (callers pass a string) or `@return url`
+# (not a real type). The main phpstan.neon runs at level 3 without WordPress
+# function signatures, so it cannot see this class of bug. This config loads the
+# WordPress stubs and runs at level 5 (argument-type checking), so a wrong
+# docblock conflicts with how callers / WP core functions actually use the value
+# and becomes a hard CI error:
+#
+#   "Parameter #1 $url of method ...::purge_url() expects array, string given"
+#   "Method ...::nocache_cssjs() has invalid return type url"
+#
+# Scoped to the two files whose public-API docblocks we guarantee. The stub file
+# is symlinked into build/ by CI / the `phpstan-phpdoc` Makefile target.
+#
+# This job intentionally only polices DOCBLOCK TYPE CORRECTNESS. The dead-code /
+# "always true|false" / redundant-defensive-check noise that level 5 surfaces on
+# this legacy code is suppressed below — those are not docblock bugs and are out
+# of scope for this linter (the main phpstan.neon owns general analysis).
+parameters:
+    level: 5
+    treatPhpDocTypesAsCertain: false
+    paths:
+        - varnish-http-purge.php
+        - debug.php
+    scanFiles:
+        - build/wordpress-stubs.php
+    bootstrapFiles:
+        - phpstan-bootstrap.php
+    ignoreErrors:
+        # --- Out of scope: dead-code / redundant-check noise (not docblock bugs) ---
+        - '#will always evaluate to (true|false)#'
+        - '#is always (true|false)\.#'
+        - '#side of && is always (true|false)#'
+        - '#in empty\(\) always exists#'
+        - '#in isset\(\) always exists and is not (nullable|falsy)#'
+        - '#in isset\(\) is not nullable#'
+        - '#Default value of the parameter#'
+        # --- Out of scope: symbols not in the WP stubs / plugin-internal classes ---
+        - '#Instantiated class VarnishTags not found#'
+        - '#Constant [A-Z_]+ not found#'
+        - '#Class (WP_CLI[a-zA-Z_]*) not found#'
+        # --- Pre-existing, unrelated to PHPDoc types (tracked separately) ---
+        - '#\$deps of function wp_register_style expects#'
+    reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,9 @@ parameters:
         - phpstan-bootstrap.php
         # WP-CLI file requires WP-CLI stubs which we don't have
         - wp-cli.php
+        # Local-only symlink to the wordpress-stubs file used by the PHPDoc
+        # linter (phpstan-phpdoc.neon). Analysing it here blows the memory limit.
+        - build/
     scanDirectories:
         - .
     bootstrapFiles:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,7 +11,8 @@ parameters:
         - wp-cli.php
         # Local-only symlink to the wordpress-stubs file used by the PHPDoc
         # linter (phpstan-phpdoc.neon). Analysing it here blows the memory limit.
-        - build/
+        # (?) = optional: build/ only exists locally, never in the main CI job.
+        - build (?)
     scanDirectories:
         - .
     bootstrapFiles:

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Ipstenu, mikeschroder, techpriester, danielbachhuber, dvershinin
 Tags: proxy, purge, cache, varnish, nginx
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 5.9.1
+Stable tag: 5.9.2
 Requires PHP: 7.4
 License: Apache License 2.0
 License URI: https://www.apache.org/licenses/LICENSE-2.0
@@ -467,6 +467,10 @@ add_filter( 'varnish_http_purge_x_varnish_header_name', 'change_varnish_header' 
 </code>
 
 == Changelog ==
+
+= 5.9.2 (2026-05) =
+* Fix: Corrected @param/@return docblock types on purge_post(), purge_url(), and related methods so they match the values actually passed and returned, removing false IDE and static-analysis warnings (reported by Sjoerd Boerrigter). No runtime behavior changes.
+* New: CI lints PHPDoc parameter/return types against WordPress function signatures to catch docblock drift automatically.
 
 = 5.9.1 (2026-05) =
 * Update: Tested up to WordPress 7.0

--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,12 @@ Plugins can hook into the purge actions as well, to filter their own events to t
 
 On a multisite network using subfolders, only <strong>network admins</strong> can purge the main site.
 
+= Keep Your Cache Warm =
+
+Purging is only half the story. Once Proxy Cache Purge empties a page, the cache for that URL is gone, so the next visitor triggers a full uncached render and waits for it. On busy sites this "cache stampede" shows up as slow pages right after every update.
+
+<a href="https://www.getpagespeed.com/cacheability-pro?ref=vhp-readme">Cacheability Pro</a> is a companion plugin that closes that gap: it automatically re-warms purged URLs in the background so visitors keep hitting fast, cached responses, and it tunes your cache headers so more of your pages stay cacheable in the first place. Proxy Cache Purge handles invalidation; Cacheability Pro handles everything around it.
+
 = Development Mode =
 
 If you're working on a site and need to turn off caching in one of two ways:

--- a/settings.php
+++ b/settings.php
@@ -853,6 +853,38 @@ sub vcl_recv {
 	 *
 	 * @since 4.0
 	 */
+	/**
+	 * Render an inline Cacheability Pro promo banner at the top of an admin page.
+	 *
+	 * Skipped when Cacheability Pro or the free Cacheability plugin is already
+	 * active, so we never advertise a product the user already has.
+	 *
+	 * @since 5.9.2
+	 *
+	 * @param string $ref UTM ref parameter identifying the placement.
+	 * @return void
+	 */
+	private function cacheability_pro_header_banner( $ref ) {
+		if ( class_exists( 'Cacheability_Pro' ) || class_exists( 'Cacheability' ) ) {
+			return;
+		}
+
+		$pro_url = 'https://www.getpagespeed.com/cacheability-pro?ref=' . rawurlencode( $ref );
+		?>
+		<div class="notice notice-info inline vhp-cacheability-header" style="margin: 12px 0; padding: 10px 12px;">
+			<p style="margin: 0.4em 0;">
+				<strong><?php esc_html_e( '🔥 Purging is only half the job.', 'varnish-http-purge' ); ?></strong>
+				<?php esc_html_e( 'After Proxy Cache Purge clears a page, the next visitor pays for the slow, uncached load.', 'varnish-http-purge' ); ?>
+				<strong><?php esc_html_e( 'Cacheability Pro', 'varnish-http-purge' ); ?></strong>
+				<?php esc_html_e( 're-warms purged URLs automatically and tunes cache headers so more of your pages stay cacheable.', 'varnish-http-purge' ); ?>
+				<a href="<?php echo esc_url( $pro_url ); ?>" target="_blank" rel="noopener" class="button button-secondary" style="margin-left: 6px;">
+					<?php esc_html_e( 'See how it works', 'varnish-http-purge' ); ?>
+				</a>
+			</p>
+		</div>
+		<?php
+	}
+
 	public function settings_page() {
 		?>
 		<div class="wrap">
@@ -860,6 +892,8 @@ sub vcl_recv {
 			<h1><?php esc_html_e( 'Proxy Cache Purge Settings', 'varnish-http-purge' ); ?></h1>
 
 			<p><?php esc_html_e( 'Proxy Cache Purge can empty the cache for different server based caching systems, including Varnish and nginx. For most users, there should be no configuration necessary as the plugin is intended to work silently, behind the scenes.', 'varnish-http-purge' ); ?></p>
+
+			<?php $this->cacheability_pro_header_banner( 'vhp-settings-header' ); ?>
 
 			<?php $this->render_health_score_widget(); ?>
 
@@ -1422,6 +1456,8 @@ sub vcl_recv {
 
 			<?php settings_errors(); ?>
 			<h1><?php esc_html_e( 'Is Caching Working?', 'varnish-http-purge' ); ?></h1>
+
+			<?php $this->cacheability_pro_header_banner( 'vhp-debug-header' ); ?>
 
 			<nav class="nav-tab-wrapper vhp-tabs">
 				<a href="#vhp-tab-e2e" class="nav-tab nav-tab-active" data-tab="vhp-tab-e2e">

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -303,8 +303,8 @@ class VarnishPurger {
 	 * This runs for ALL upgrades (theme, plugin, and core) to account for
 	 * the complex nature that are upgrades.
 	 *
-	 * @param  array $upgrader_object WP_Upgrader instance (unused).
-	 * @param  array $hook_extra Extra hook arguments (unused).
+	 * @param  \WP_Upgrader $upgrader_object WP_Upgrader instance (unused).
+	 * @param  array        $hook_extra Extra hook arguments (unused).
 	 * @since 4.8
 	 */
 	public function check_upgrades( $upgrader_object, $hook_extra ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
@@ -1445,7 +1445,7 @@ class VarnishPurger {
 	 * Parse the URL for proxy proxies
 	 *
 	 * @since 1.0
-	 * @param array $url - The url to be purged.
+	 * @param string $url - The url to be purged.
 	 * @access protected
 	 */
 	public static function purge_url( $url ) {
@@ -1942,7 +1942,7 @@ class VarnishPurger {
 	 *
 	 * @access public
 	 * @param mixed $post_id - The ID of the post to be purged.
-	 * @return array()
+	 * @return array
 	 */
 	public function generate_urls( $post_id ) {
 		$this->purge_post( $post_id );
@@ -1954,7 +1954,7 @@ class VarnishPurger {
 	 * Flush the post
 	 *
 	 * @since 1.0
-	 * @param array $post_id - The ID of the post to be purged.
+	 * @param int $post_id - The ID of the post to be purged.
 	 * @access public
 	 */
 	public function purge_post( $post_id ) {

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -3,7 +3,7 @@
  * Plugin Name: Proxy Cache Purge
  * Plugin URI: https://github.com/dvershinin/varnish-http-purge
  * Description: Automatically empty cached pages when content on your site is modified.
- * Version: 5.9.1
+ * Version: 5.9.2
  * Requires at least: 5.0
  * Tested up to: 7.0
  * Requires PHP: 7.4
@@ -43,7 +43,7 @@ class VarnishPurger {
 	 * Version Number
 	 * @var string
 	 */
-	public static $version = '5.9.1';
+	public static $version = '5.9.2';
 
 	/**
 	 * List of URLs to be purged


### PR DESCRIPTION
## What & why

A WordPress.org forum user (Sjoerd Boerrigter) reported wrong \`@param\` types: \`purge_post()\` documented \`@param array \$post_id\` (it takes an int) and \`purge_url()\` documented \`@param array \$url\` (it takes a string). No runtime bug, but it triggers false IDE / static-analysis warnings.

Beyond fixing the docblocks, this adds a **CI linter that catches this class of bug**, and surfaces the companion product on three pages that previously had no mention.

## Proof the linter works (failing job → green)

The first commit (\`CI: add PHPStan PHPDoc-type linter\`) lands the linter **without** the docblock fixes on purpose, so the new **PHPStan PHPDoc Types** job goes red and demonstrates real detection:

\`\`\`
purge_url() expects array, string given        (×10 callers)
purge_post() expects array, int given
nocache_cssjs() has invalid return type url
@return array()  (malformed)
\`\`\`

The follow-up commit corrects the docblocks and the job goes green. Locally: 33 errors → 0.

### How it works
\`phpstan-phpdoc.neon\` runs PHPStan at level 5 with the WordPress function stubs loaded (\`scanFiles\`), so a docblock type that disagrees with how callers / WP core actually use the value becomes a hard error. Scoped to \`varnish-http-purge.php\` + \`debug.php\`; dead-code / redundant-check noise is suppressed (out of scope). Wired into \`make lint\` and a new \`phpstan-phpdoc\` CI job. No signature changes → no back-compat risk.

## Docblock fixes
- \`purge_url()\`: \`@param array \$url\` → \`string\`
- \`purge_post()\`: \`@param array \$post_id\` → \`int\`
- \`check_upgrades()\`: \`@param array \$upgrader_object\` → \`\WP_Upgrader\`
- \`generate_urls()\`: \`@return array()\` → \`array\`
- \`nocache_cssjs()\`: \`@return url\` → \`string\`

## Cacheability Pro placements (sales)
Added to three previously-untapped, guarded surfaces: readme.txt \"Keep Your Cache Warm\" section, Settings page header, and the Check Caching / diagnostics page header.

## Release
Bumps to **5.9.2** (version triple + changelog). All tests green locally (149 passed). Tag push will deploy to WordPress.org.