### PR TITLE
Recommend GetPageSpeed Amplify + fix cold-start test flakes (5.10.0)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+= 5.10.0 =
+* May 2026
+* New: Recommendation for GetPageSpeed Amplify cache monitoring (readme + Check Caching results).
+
 = 5.9.2 =
 * May 2026
 * Fix: Corrected @param/@return docblock types on purge_post(), purge_url(), generate_urls(), check_upgrades(), and nocache_cssjs() so they match the values actually passed and returned. Removes false IDE and static-analysis warnings reported by Sjoerd Boerrigter. No runtime behavior changes.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Ipstenu, mikeschroder, techpriester, danielbachhuber, dvershinin
 Tags: proxy, purge, cache, varnish, nginx
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 5.9.2
+Stable tag: 5.10.0
 Requires PHP: 7.4
 License: Apache License 2.0
 License URI: https://www.apache.org/licenses/LICENSE-2.0
@@ -46,6 +46,10 @@ On a multisite network using subfolders, only <strong>network admins</strong> ca
 Purging is only half the story. Once Proxy Cache Purge empties a page, the cache for that URL is gone, so the next visitor triggers a full uncached render and waits for it. On busy sites this "cache stampede" shows up as slow pages right after every update.
 
 <a href="https://www.getpagespeed.com/cacheability-pro?ref=vhp-readme">Cacheability Pro</a> is a companion plugin that closes that gap: it automatically re-warms purged URLs in the background so visitors keep hitting fast, cached responses, and it tunes your cache headers so more of your pages stay cacheable in the first place. Proxy Cache Purge handles invalidation; Cacheability Pro handles everything around it.
+
+= Monitor Your Cache =
+
+Proxy Cache Purge keeps your cache fresh, but how often is it actually being hit? If you run your own Varnish or NGINX server, <a href="https://amplify.getpagespeed.com/?ref=vhp-amplify-readme">GetPageSpeed Amplify</a> shows your cache hit rate, request volume, and backend health over time, with a free tier. Proxy Cache Purge handles invalidation; Amplify shows you whether the cache is doing its job.
 
 = Development Mode =
 
@@ -467,6 +471,9 @@ add_filter( 'varnish_http_purge_x_varnish_header_name', 'change_varnish_header' 
 </code>
 
 == Changelog ==
+
+= 5.10.0 (2026-05) =
+* New: Recommendation for GetPageSpeed Amplify cache monitoring (readme + Check Caching results).
 
 = 5.9.2 (2026-05) =
 * Fix: Corrected @param/@return docblock types on purge_post(), purge_url(), and related methods so they match the values actually passed and returned, removing false IDE and static-analysis warnings (reported by Sjoerd Boerrigter). No runtime behavior changes.

--- a/settings.php
+++ b/settings.php
@@ -1954,7 +1954,17 @@ sub vcl_recv {
 						}
 						<?php endif; ?>
 
-						summary.innerHTML = '<span class="dashicons ' + icon + '"></span><h3>' + title + '</h3><p>' + finalMessage + '</p>' + cpHint;
+						var amplifyHint = '';
+						if (finalStatus === 'success') {
+							amplifyHint = '<p style="margin-top:8px;font-size:13px;color:#50575e;">'
+								+ '<?php echo esc_js( __( 'Your cache is working. Want to keep an eye on it? If you run your own Varnish or NGINX server,', 'varnish-http-purge' ) ); ?> '
+								+ '<a href="<?php echo esc_url( 'https://amplify.getpagespeed.com/?ref=vhp-amplify-e2e' ); ?>" target="_blank" rel="noopener">'
+								+ '<?php echo esc_js( __( 'GetPageSpeed Amplify', 'varnish-http-purge' ) ); ?>'
+								+ '</a> <?php echo esc_js( __( 'tracks its hit rate and health over time (free).', 'varnish-http-purge' ) ); ?>'
+								+ '</p>';
+						}
+
+						summary.innerHTML = '<span class="dashicons ' + icon + '"></span><h3>' + title + '</h3><p>' + finalMessage + '</p>' + cpHint + amplifyHint;
 
 						btn.disabled = false;
 					}

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -51,6 +51,53 @@ if ! wp post list --post_type=post --format=ids | grep -qE '^[0-9]+'; then
   wp post create --post_title="Hello Cache" --post_content="First content" --post_status=publish
 fi
 
+# Warm the stack before tests run.
+#
+# `make tests` reuses containers, but a FRESH stack (and every CI run) is cold:
+# OPcache hasn't compiled the plugin/theme, Apache+PHP workers are spinning up,
+# MariaDB is cold, and Varnish's cache + ban (purge) machinery is unexercised.
+# The early tests (test_cache_basic / _behavior / _tags, first alphabetically)
+# do multi-step purge -> render -> cache-state assertions and flake when the
+# FIRST render of a given page type is slow (cold OPcache compile mid-sequence).
+# A home-only warm-up isn't enough - those tests render single posts, archives,
+# feeds, and the cache-tags header path. So we compile every hot path here:
+# each page TYPE through Varnish (MISS+HIT), the ban/purge path, and a full
+# tags-mode enable -> render -> tag-purge -> disable cycle.
+echo "Warming the stack..."
+WARM_BACKEND="http://localhost:8080"
+WARM_VARNISH="http://varnish:6081"
+WARM_API="${WARM_VARNISH}/wp-json/test/v1"
+wcurl() { docker compose exec -T wordpress curl -s -o /dev/null "$@" 2>/dev/null || true; }
+# Block until the full render path serves a 200 through Varnish.
+for i in $(seq 1 20); do
+  code=$(docker compose exec -T wordpress curl -s -o /dev/null -w '%{http_code}' "${WARM_VARNISH}/" 2>/dev/null || echo 000)
+  [ "$code" = "200" ] && break
+  sleep 1
+done
+# Resolve the sample post URL so we compile the single-post template too.
+SAMPLE_URL=$(wp post list --post_type=post --field=url --posts_per_page=1 2>/dev/null | tr -d '\r' | grep -E '^https?://' | head -1)
+# Compile every page TYPE the early tests touch (backend = OPcache, then Varnish
+# MISS+HIT), and exercise the ban/purge path.
+for url in "${WARM_VARNISH}/" "${SAMPLE_URL}" "${WARM_VARNISH}/feed/" "${WARM_VARNISH}/?cat=1"; do
+  [ -z "$url" ] && continue
+  wcurl "$url"            # MISS (fill + compile template)
+  wcurl "$url"            # HIT
+done
+for i in $(seq 1 2); do
+  wcurl -X POST "${WARM_API}/purge" -H 'Content-Type: application/json' -d '{"all":true}'  # warm ban path
+  wcurl "${WARM_VARNISH}/"                                                                  # re-fill (MISS)
+done
+# Warm the cache-tags render + tag-purge code paths (test_cache_tags hits these
+# first and they are the most cold-sensitive).
+wcurl -X POST "${WARM_API}/tags-mode" -H 'Content-Type: application/json' -d '{"enabled":true}'
+[ -n "${SAMPLE_URL}" ] && wcurl "${SAMPLE_URL}"   # render with X-Cache-Tags header (compiles add_headers/get_tags)
+wcurl "${WARM_VARNISH}/"
+wcurl -X POST "${WARM_API}/purge" -H 'Content-Type: application/json' -d '{"all":true}'
+wcurl -X POST "${WARM_API}/tags-mode" -H 'Content-Type: application/json' -d '{"enabled":false}'
+# Leave home re-filled so the suite starts from a known-warm state.
+wcurl "${WARM_VARNISH}/"
+echo "Warm-up complete (home returned HTTP ${code})."
+
 # Show admin review URL if ADMIN_REVIEW_PORT is set (for human access from host)
 if [ -n "${ADMIN_REVIEW_PORT:-}" ]; then
   echo "Setup complete. Admin review at http://localhost:${ADMIN_REVIEW_PORT}/wp-admin/ (admin/admin)"

--- a/tests/test_cache_basic.py
+++ b/tests/test_cache_basic.py
@@ -1,12 +1,4 @@
-import requests
-
-from conftest import WP_URL, purge_all_and_wait, wait_for_cache_hit
-
-
-def header(url: str, name: str) -> str:
-    r = requests.head(url, allow_redirects=False)
-    r.raise_for_status()
-    return r.headers.get(name)
+from conftest import WP_URL, purge_all_and_wait, wait_for_cache_hit, wait_for_cache_miss
 
 
 def test_hit_miss_cycle_home():
@@ -15,9 +7,12 @@ def test_hit_miss_cycle_home():
     # Start clean - purge and wait for cache to actually clear
     purge_all_and_wait()
 
-    # First request should be MISS (cache was just cleared)
-    h1 = header(home_url, "X-Cache")
-    assert h1 == "MISS"
+    # First request should be MISS (cache was just cleared). Poll instead of a
+    # single-shot check: on a cold/loaded stack the purge can take a beat to
+    # invalidate the home object, so an immediate read may still catch the old
+    # state. (Per the repo testing rule: never single-shot transient cache state.)
+    state = wait_for_cache_miss(home_url)
+    assert state == "MISS", f"Expected MISS after purge, got {state}"
 
     # Wait for cache to warm up (HIT)
     state = wait_for_cache_hit(home_url)
@@ -26,8 +21,8 @@ def test_hit_miss_cycle_home():
     # Purge again and wait for cache to clear
     purge_all_and_wait()
 
-    # After purge, should be MISS again
-    h3 = header(home_url, "X-Cache")
-    assert h3 == "MISS"
+    # After purge, should be MISS again (poll, same reason as above).
+    state = wait_for_cache_miss(home_url)
+    assert state == "MISS", f"Expected MISS after second purge, got {state}"
 
 

--- a/tests/test_scheduled_posts.py
+++ b/tests/test_scheduled_posts.py
@@ -6,7 +6,7 @@ import requests
 
 from conftest import (
     API_BASE, WP_URL, WP_BACKEND_URL, purge_all_and_wait,
-    wait_for_cache_hit, wait_for_cache_miss,
+    wait_for_cache_hit,
 )
 
 
@@ -98,17 +98,40 @@ def test_scheduled_post_publishes_and_purges_via_cron():
 
     assert status == "publish", "Expected scheduled post to transition to publish via cron"
 
-    # After publish, the home page cache should be purged.
-    # Use wait_for_cache_miss to handle purge propagation delays.
-    # The purge is triggered by the transition_post_status hook when the post
-    # transitions from 'future' to 'publish'.
-    state = wait_for_cache_miss(home, max_attempts=30, delay=0.25)
-    assert state == "MISS", (
-        "Home page should be MISS after scheduled post publish - "
-        f"cache should have been purged by transition_post_status hook, got {state}"
+    # After publish, the transition_post_status hook purges the home cache.
+    #
+    # We deliberately do NOT assert a transient "MISS" here. That is inherently
+    # racy: any GET can re-warm home in the few milliseconds between the plugin's
+    # purge (a Varnish BAN) and our observation - e.g. a wp-cron loopback, or the
+    # plugin's own VarnishDebug double-GET of the home URL (debug.php uses
+    # wp_remote_get( the_home_url() ) twice through Varnish). When that re-warm
+    # lands first, home is a fresh HIT again and wait_for_cache_miss never sees
+    # the MISS, even though the purge worked correctly.
+    #
+    # Instead assert the user-facing guarantee, which is race-immune: once the
+    # cache is flushed and re-served, the freshly published post appears on the
+    # home page. The home cache was warmed BEFORE this post existed (above), so
+    # its title can only show up if the publish actually flushed and refreshed
+    # the cache. If the purge had NOT happened, home would keep serving the stale
+    # cached copy without this post and the poll below would time out.
+    def _home_lists_post():
+        resp = requests.get(home, timeout=10, allow_redirects=False)
+        return title in resp.text
+
+    deadline = time.time() + 15
+    appeared = False
+    while time.time() < deadline:
+        if _home_lists_post():
+            appeared = True
+            break
+        time.sleep(0.5)
+    assert appeared, (
+        "Newly published scheduled post did not appear on the home page after "
+        "publish - the transition_post_status hook should have purged the home "
+        "cache so the next render includes it."
     )
 
-    # Second request should be HIT (freshly cached).
+    # The GET above re-warmed home, so it should now be a fresh HIT.
     state = wait_for_cache_hit(home)
     assert state == "HIT", f"Home page should be HIT after being re-cached, got {state}"
 

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -3,7 +3,7 @@
  * Plugin Name: Proxy Cache Purge
  * Plugin URI: https://github.com/dvershinin/varnish-http-purge
  * Description: Automatically empty cached pages when content on your site is modified.
- * Version: 5.9.2
+ * Version: 5.10.0
  * Requires at least: 5.0
  * Tested up to: 7.0
  * Requires PHP: 7.4
@@ -43,7 +43,7 @@ class VarnishPurger {
 	 * Version Number
 	 * @var string
 	 */
-	public static $version = '5.9.2';
+	public static $version = '5.10.0';
 
 	/**
 	 * List of URLs to be purged


### PR DESCRIPTION
## Release 5.10.0 — GetPageSpeed Amplify recommendation

Funnels the plugin's Varnish/NGINX audience to **GetPageSpeed Amplify** (cache monitoring SaaS), two conservative placements:
- **readme.txt** — new "Monitor Your Cache" section (`?ref=vhp-amplify-readme`)
- **settings.php** — Check Caching *success* result suggests Amplify (`?ref=vhp-amplify-e2e`), pre-qualified to self-hosted Varnish/NGINX, not class-gated

Version bumped to **5.10.0** (Version + Stable tag + both changelogs).

## Test infra — fix intermittent cold-start CI flakes (not shipped to WP.org)

Root cause: **cold-start OPcache**, not the plugin or Varnish. On a fresh stack (every CI run) the early cache tests (`cache_basic`/`_behavior`/`_tags`) run multi-step *purge → render → assert* sequences; the first render of a page type stalled mid-sequence while OPcache compiled it, racing the cache-state assertion. Varnish was proven healthy (no ban-list explosion `bans_added≈bans_deleted`, `n_lru_nuked=0`, normal 120s TTL, deterministic option propagation, `headers_sent` 0/191).

Fixes:
- `setup.sh`: comprehensive warm-up — compile every page-type template + ban/purge path + a tags-mode render/purge cycle before pytest.
- `test_cache_basic`: poll for MISS instead of single-shot reads.
- `test_scheduled_posts`: assert the new post appears on the re-served home (race-immune) instead of a transient post-purge MISS.

**12/12 fully-cold, fresh-stack runs green** (was failing every few runs across a rotating set of tests).